### PR TITLE
Add matioCpp examples

### DIFF
--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -5,6 +5,18 @@
 # BSD-3-Clause license. See the accompanying LICENSE file for details.
 
 set(CIRCULAR_BUFFER_EXAMPLE_SRC circular-buffer-example.cpp)
+set(MATIO_VECTOR_EXAMPLE_SRC matio_vector_example.cpp)
+set(MATIO_MATRIX_EXAMPLE_SRC matio_matrix_example.cpp)
+set(MATIO_TIMESERIES_EXAMPLE_SRC matio_timeseries_example.cpp)
+
+
 add_executable(circular-buffer-example ${CIRCULAR_BUFFER_EXAMPLE_SRC})
+add_executable(matio_vector_example ${MATIO_VECTOR_EXAMPLE_SRC})
+add_executable(matio_matrix_example ${MATIO_MATRIX_EXAMPLE_SRC})
+add_executable(matio_timeseries_example ${MATIO_TIMESERIES_EXAMPLE_SRC})
+
 target_compile_features(circular-buffer-example PUBLIC cxx_std_14)
 target_link_libraries(circular-buffer-example Boost::boost)
+target_link_libraries(matio_vector_example PRIVATE matioCpp::matioCpp)
+target_link_libraries(matio_matrix_example PRIVATE matioCpp::matioCpp)
+target_link_libraries(matio_timeseries_example PRIVATE matioCpp::matioCpp)

--- a/src/examples/matio_matrix_example.cpp
+++ b/src/examples/matio_matrix_example.cpp
@@ -1,0 +1,41 @@
+#include <vector>
+#include <matioCpp/matioCpp.h>
+
+using namespace std;
+
+int main(int argc, char *argv[])
+{
+  matioCpp::File file = matioCpp::File::Create("test_int.mat");
+  matioCpp::File file_double = matioCpp::File::Create("test_double.mat");
+  matioCpp::File file_3d = matioCpp::File::Create("test_3d.mat");
+
+  // Create a matio matrix of ints 2x2 (from vector)
+  vector<int> in = {2, 4, 7, 10};
+  matioCpp::MultiDimensionalArray<int> out("test", {2,2}, in.data());
+
+  // Create a matio matrix of ints 2x2x2 (from vector)
+  vector<int> in_3d = {2, 4, 7, 9, 10, 13, 21, 24};
+  matioCpp::MultiDimensionalArray<int> out_3d("test", {2,2,2}, in_3d.data());
+
+  // create a matio matrix of doubles
+  vector<double> in_double = {2.0, 4.0, 6.0, 8.0};
+  matioCpp::MultiDimensionalArray<double> out_double("test", {2,2}, in_double.data());
+
+  // adding another 2x2 matrix to an existing matrix
+  out_double.resize({2, 2, 2}); // clears previous data
+  out_double({0,0,0}) = in_double[0];
+  out_double({0,1,0}) = in_double[1];
+  out_double({0,0,1}) = in_double[2];
+  out_double({0,1,1}) = in_double[3];
+  out_double({1,0,0}) = 40.0;
+  out_double({1,1,0}) = 50.0;
+  out_double({1,0,1}) = 60.0;
+  out_double({1,1,1}) = 70.0;
+  // {#vectors_vectors, #vectors, #element}
+  
+  file.write(out);
+  file_double.write(out_double);
+  file_3d.write(out_3d);
+
+  return 0;
+}

--- a/src/examples/matio_timeseries_example.cpp
+++ b/src/examples/matio_timeseries_example.cpp
@@ -1,0 +1,79 @@
+#include <vector>
+#include <matioCpp/matioCpp.h>
+
+using namespace std;
+
+int main(int argc, char *argv[])
+{
+  matioCpp::File file = matioCpp::File::Create("test_timeseries.mat");
+
+
+  // first we take care of the timestamps vector
+  unsigned long int num_time_stamps = 3;
+  vector<double> timestamps_vect{0.5, 1.0, 1.5};
+
+
+  // convert from c++ vector to matioCpp vector
+  matioCpp::Vector<double> timestamps("timestamps");
+  timestamps = timestamps_vect;
+
+
+  // now we initialize the proto-timeseries structure
+  vector<matioCpp::Variable> timeSeries_data;
+
+
+  // and the structures for the actual data too
+  vector<matioCpp::Variable> data_left_arm;
+  vector<matioCpp::Variable> data_right_arm;
+
+
+  // here we create the matioCpp vector for the dimensions of the joints vector (#steps, #joints)
+  vector<int> dimensions_left_vect{(int)num_time_stamps, 4};
+  matioCpp::Vector<int> dimensions_left("dimensions");
+  dimensions_left = dimensions_left_vect;
+
+
+  // now we start populating the proto-structure for the left arm data
+  // we start by creating an empty vector with the dimensions specified
+  // (In practice, we will be creating the matioCpp vector as we did for the dimensions)
+  data_left_arm.emplace_back(matioCpp::MultiDimensionalArray<double>("joints", {num_time_stamps,4}));
+
+  // now we add also the dimensions vector to this proto-structure
+  data_left_arm.emplace_back(dimensions_left);
+
+  // and finally we convert the proto-structure into an actual matioCpp Struct
+  matioCpp::Struct left_arm_struct("left_arm", data_left_arm);
+
+
+  
+  // now we repeat the steps above but for the right arm (in practice just changing the dimensions)
+  vector<int> dimensions_right_vect{(int)num_time_stamps, 6};
+  matioCpp::Vector<int> dimensions_right("dimensions");
+  dimensions_right = dimensions_right_vect;
+
+  data_right_arm.emplace_back(matioCpp::MultiDimensionalArray<double>("joints", {num_time_stamps,6}));
+  data_right_arm.emplace_back(dimensions_right);
+  matioCpp::Struct right_arm_struct("right_arm", data_right_arm);
+
+
+  // now we create a vector with all the structs (signals) we have....
+  vector<matioCpp::Struct> signalsVect{left_arm_struct, right_arm_struct};
+
+  // ...and convert this vector into a matioCpp array of structures (StructArray)
+  matioCpp::StructArray signals("signals", {1,2}, signalsVect);
+
+
+  // Now, we populate the timeseries proto-struct with the timestamp vector (common for both signals) and the array of signals
+  timeSeries_data.emplace_back(timestamps);
+  timeSeries_data.emplace_back(signals);
+
+  
+  // finally we convert the proto-structure into a matioCpp Struct, ready for writing
+  matioCpp::Struct timeSeries("output", timeSeries_data);
+  
+
+  file.write(timeSeries);
+
+  return 0;
+}
+

--- a/src/examples/matio_timeseries_example.cpp
+++ b/src/examples/matio_timeseries_example.cpp
@@ -41,11 +41,13 @@ int main(int argc, char *argv[])
   // now we add also the dimensions vector to this proto-structure
   data_left_arm.emplace_back(dimensions_left);
 
+  // we can also set the name of the signal inside this data
+  data_left_arm.emplace_back(matioCpp::String("name", "left_arm"));
+
   // and finally we convert the proto-structure into an actual matioCpp Struct
   matioCpp::Struct left_arm_struct("left_arm", data_left_arm);
 
-
-  
+ 
   // now we repeat the steps above but for the right arm (in practice just changing the dimensions)
   vector<int> dimensions_right_vect{(int)num_time_stamps, 6};
   matioCpp::Vector<int> dimensions_right("dimensions");
@@ -53,17 +55,21 @@ int main(int argc, char *argv[])
 
   data_right_arm.emplace_back(matioCpp::MultiDimensionalArray<double>("joints", {num_time_stamps,6}));
   data_right_arm.emplace_back(dimensions_right);
+  data_right_arm.emplace_back(matioCpp::String("name", "right_arm"));
   matioCpp::Struct right_arm_struct("right_arm", data_right_arm);
 
 
+
   // now we create a vector with all the structs (signals) we have....
-  vector<matioCpp::Struct> signalsVect{left_arm_struct, right_arm_struct};
+  vector<matioCpp::Variable> signalsVect;
+  signalsVect.emplace_back(left_arm_struct);
+  signalsVect.emplace_back(right_arm_struct);
 
-  // ...and convert this vector into a matioCpp array of structures (StructArray)
-  matioCpp::StructArray signals("signals", {1,2}, signalsVect);
+  // ...and convert this vector into a matioCpp Struct
+  matioCpp::Struct signals("signals", signalsVect);
 
 
-  // Now, we populate the timeseries proto-struct with the timestamp vector (common for both signals) and the array of signals
+  // Now, we populate the timeseries proto-struct with the timestamp vector (common for both signals) and the struct of signals
   timeSeries_data.emplace_back(timestamps);
   timeSeries_data.emplace_back(signals);
 

--- a/src/examples/matio_vector_example.cpp
+++ b/src/examples/matio_vector_example.cpp
@@ -1,0 +1,25 @@
+#include <vector>
+#include <matioCpp/matioCpp.h>
+
+using namespace std;
+
+int main(int argc, char *argv[])
+{
+  matioCpp::File file = matioCpp::File::Create("test_int.mat");
+  matioCpp::File file_double = matioCpp::File::Create("test_double.mat");
+
+  // Create a matio vector of ints
+  vector<int> in = {2, 4, 7, 10};
+  matioCpp::Vector<int> out("test");
+  out = in;  //"in" is automatically converted to span!
+
+  // create a matio vector of doubles
+  vector<double> in_double = {2.0, 4.0, 6.0, 8.0};
+  matioCpp::Vector<double> out_double("test");
+  out_double = in_double;  //"in" is automatically converted to span!
+  
+  file.write(out);
+  file_double.write(out_double);
+
+  return 0;
+}


### PR DESCRIPTION
This pull-request introduces 2 simple examples of matioCpp use (for vectors and matrices), and an example implementation of the structure for saving timeseries in `.mat` files.

This fixes #4 and fixes #8 . 