### PR TITLE
First draft of Buffer API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,9 +59,9 @@ jobs:
     - name: Dependencies [macOS]
       if: matrix.os == 'macOS-latest'
       run: |
-        # Workaround for https://github.com/actions/virtual-environments/issues/1811#issuecomment-718475660
-        brew unlink python@3.8
         brew update
+        # Workaround for https://github.com/robotology/robotology-superbuild/issues/565
+        brew upgrade  python@3.9 || brew link --overwrite python@3.9
         brew upgrade
         brew install cmake libmatio ace eigen boost
 

--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -9,6 +9,7 @@ set(CIRCULAR_BUFFER_RECORD_EXAMPLE_SRC circular_buffer_record_example.cpp)
 set(MATIO_VECTOR_EXAMPLE_SRC matio_vector_example.cpp)
 set(MATIO_MATRIX_EXAMPLE_SRC matio_matrix_example.cpp)
 set(MATIO_TIMESERIES_EXAMPLE_SRC matio_timeseries_example.cpp)
+set(TELEMETRY_BUFFER_EXAMPLE_SRC telemetry_buffer_example.cpp)
 
 
 add_executable(circular_buffer_example ${CIRCULAR_BUFFER_EXAMPLE_SRC})
@@ -16,15 +17,22 @@ add_executable(circular_buffer_record_example ${CIRCULAR_BUFFER_RECORD_EXAMPLE_S
 add_executable(matio_vector_example ${MATIO_VECTOR_EXAMPLE_SRC})
 add_executable(matio_matrix_example ${MATIO_MATRIX_EXAMPLE_SRC})
 add_executable(matio_timeseries_example ${MATIO_TIMESERIES_EXAMPLE_SRC})
+add_executable(telemetry_buffer_example ${TELEMETRY_BUFFER_EXAMPLE_SRC})
 
 target_compile_features(circular_buffer_example PUBLIC cxx_std_14)
 target_compile_features(circular_buffer_record_example PUBLIC cxx_std_14)
+target_compile_features(telemetry_buffer_example PUBLIC cxx_std_14)
+
 target_link_libraries(circular_buffer_example Boost::boost)
 target_link_libraries(circular_buffer_record_example Boost::boost
                                                      YARP::YARP_conf
                                                      YARP::YARP_os
                                                      YARP::YARP_init
                                                      YARP::YARP_telemetry)
+target_link_libraries(telemetry_buffer_example YARP::YARP_conf
+                                               YARP::YARP_os
+                                               YARP::YARP_init
+                                               YARP::YARP_telemetry)
 target_link_libraries(matio_vector_example PRIVATE matioCpp::matioCpp)
 target_link_libraries(matio_matrix_example PRIVATE matioCpp::matioCpp)
 target_link_libraries(matio_timeseries_example PRIVATE matioCpp::matioCpp)

--- a/src/examples/circular_buffer_record_example.cpp
+++ b/src/examples/circular_buffer_record_example.cpp
@@ -80,7 +80,7 @@ using namespace yarp::telemetry;
 
     cout<<"The capacity is: "<<cb_d.capacity()<<" and the size is: "<<cb_d.size()<<std::endl;
     cout<<"The circular buffer contains:"<<endl;
-    for (auto& c_el : cb_i) {
+    for (auto& c_el : cb_d) {
         cout<<c_el.m_ts.getCount() << " " << std::setw( 14 ) << std::setprecision( 14 ) << c_el.m_ts.getTime() << " | " << c_el.m_datum<<std::endl;
     }
 
@@ -92,7 +92,7 @@ using namespace yarp::telemetry;
 
     cout<<"The capacity is: "<<cb_d.capacity()<<" and the size is: "<<cb_d.size()<<std::endl;
     cout<<"The circular buffer contains:"<<endl;
-    for (auto& c_el : cb_i) {
+    for (auto& c_el : cb_d) {
         total_payload += c_el.getPayload();
         cout<<c_el.m_ts.getCount() << " " << std::setw( 14 ) << std::setprecision( 14 ) << c_el.m_ts.getTime() << " | " << c_el.m_datum<<std::endl;
     }

--- a/src/examples/telemetry_buffer_example.cpp
+++ b/src/examples/telemetry_buffer_example.cpp
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+
+#include <yarp/os/Time.h>
+#include <yarp/os/Network.h>
+#include <yarp/telemetry/Buffer.h>
+
+#include <iostream>
+#include <iomanip>
+#include <chrono>
+#include <thread>
+#include <vector>
+
+using namespace std;
+using namespace yarp::os;
+using namespace yarp::telemetry;
+
+ int main()
+ {
+    Network yarp;
+
+    std::cout<<"XXXXXXXX TELEMETRY BUFFER OF INT XXXXXXXX"<<std::endl;
+    yarp::telemetry::Buffer<int32_t> cb_i(3, {1,1}, "buffer_int32_t");
+
+    auto count = 0;
+    cout<<"The space available is: "<<cb_i.getBufferFreeSpace()<<std::endl;
+    // Insert threee elements into the buffer.
+    cb_i.push_back(Record(Stamp(count++, yarp::os::Time::now()), 1));
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    cb_i.push_back(Record(Stamp(count++, yarp::os::Time::now()), 2));
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    cb_i.push_back(Record(Stamp(count++, yarp::os::Time::now()), 3));
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    cout<<"The space available is: "<<cb_i.getBufferFreeSpace()<<std::endl;
+    cout<<"The circular buffer contains:"<<endl;
+    for (auto& c_el : cb_i) {
+        cout<<c_el.m_ts.getCount() << " " << std::setw( 14 ) << std::setprecision( 14 ) << c_el.m_ts.getTime() << " | " << c_el.m_datum<<std::endl;
+    }
+
+    cb_i.push_back(Record(Stamp(count++, yarp::os::Time::now()), 4));
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    cb_i.push_back(Record(Stamp(count++, yarp::os::Time::now()), 5));
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+
+    cout<<"The space available is: "<<cb_i.getBufferFreeSpace()<<std::endl;
+    cout<<"The circular buffer contains:"<<endl;
+    for (auto& c_el : cb_i) {
+        cout<<c_el.m_ts.getCount() << " " << std::setw( 14 ) << std::setprecision( 14 ) << c_el.m_ts.getTime() << " | " << c_el.m_datum<<std::endl;
+    }
+
+
+    std::cout<<"XXXXXXXX TELEMETRY BUFFER OF DOUBLE XXXXXXXX"<<std::endl;
+
+    yarp::telemetry::Buffer<double> cb_d(3, "buffer_double");
+
+    count = 0;
+    cout<<"The space available is: "<<cb_d.getBufferFreeSpace()<<std::endl;
+    // Insert threee elements into the buffer.
+    cb_d.push_back(Record(Stamp(count++, yarp::os::Time::now()), 0.1));
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    cb_d.push_back(Record(Stamp(count++, yarp::os::Time::now()), 0.2));
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    cb_d.push_back(Record(Stamp(count++, yarp::os::Time::now()), 0.3));
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    cout<<"The space available is: "<<cb_d.getBufferFreeSpace()<<std::endl;
+    cout<<"The circular buffer contains:"<<endl;
+    for (auto& c_el : cb_d) {
+        cout<<c_el.m_ts.getCount() << " " << std::setw( 14 ) << std::setprecision( 14 ) << c_el.m_ts.getTime() << " | " << c_el.m_datum<<std::endl;
+    }
+
+    cb_d.push_back(Record(Stamp(count++, yarp::os::Time::now()), 0.4));
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    cb_d.push_back(Record(Stamp(count++, yarp::os::Time::now()), 0.5));
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+
+    cout<<"The space available is: "<<cb_d.getBufferFreeSpace()<<std::endl;
+    cout<<"The circular buffer contains:"<<endl;
+    for (auto& c_el : cb_d) {
+        cout<<c_el.m_ts.getCount() << " " << std::setw( 14 ) << std::setprecision( 14 ) << c_el.m_ts.getTime() << " | " << c_el.m_datum<<std::endl;
+    }
+
+    std::cout<<"XXXXXXXX TELEMETRY BUFFER OF VECTOR OF DOUBLE XXXXXXXX"<<std::endl;
+
+    yarp::telemetry::Buffer<vector<double>> cb_v(3,{3,1}, "buffer_int32_t");
+
+    cout<<"The space available is: "<<cb_v.getBufferFreeSpace()<<std::endl;
+    // Insert threee elements into the buffer.
+    cb_v.push_back(Record(Stamp(count++, yarp::os::Time::now()), vector<double>{0.1, 0.2, 0.3}));
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    cb_v.push_back(Record(Stamp(count++, yarp::os::Time::now()), vector<double>{0.3, 0.4, 0.5}));
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    cb_v.push_back(Record(Stamp(count++, yarp::os::Time::now()), vector<double>{0.6, 0.7, 0.8}));
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    cout<<"The space available is: "<<cb_v.getBufferFreeSpace()<<std::endl;
+    cout<<"The circular buffer contains:"<<endl;
+    for (auto& c_el : cb_v) {
+        cout<<c_el.m_ts.getCount() << " " << std::setw( 14 ) << std::setprecision( 14 ) << c_el.m_ts.getTime() << " | " ;
+        for(const auto& v_el : c_el.m_datum)
+        {
+             cout<<v_el<<" ";
+        }
+        cout<<std::endl;
+    }
+
+    cb_v.push_back(Record(Stamp(count++, yarp::os::Time::now()), vector<double>{0.9, 1.0, 1.1}));
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    cb_v.push_back(Record(Stamp(count++, yarp::os::Time::now()), vector<double>{1.2, 1.3, 1.4}));
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+
+    cout<<"The space available is: "<<cb_v.getBufferFreeSpace()<<std::endl;
+    cout<<"The circular buffer contains:"<<endl;
+    for (auto& c_el : cb_v) {
+        cout<<c_el.m_ts.getCount() << " " << std::setw( 14 ) << std::setprecision( 14 ) << c_el.m_ts.getTime() << " | " ;
+        for(const auto& v_el : c_el.m_datum)
+        {
+             cout<<v_el<<" ";
+        }
+        cout<<std::endl;
+    }
+
+
+    return 0;
+ }

--- a/src/libYARP_telemetry/src/CMakeLists.txt
+++ b/src/libYARP_telemetry/src/CMakeLists.txt
@@ -11,6 +11,7 @@ set(YARP_telemetry_HDRS
   yarp/telemetry/api.h
   yarp/telemetry/Test.h
   yarp/telemetry/Record.h
+  yarp/telemetry/Buffer.h
 )
 set(YARP_telemetry_SRCS
   yarp/telemetry/Test.cpp
@@ -50,6 +51,7 @@ target_compile_features(YARP_telemetry PUBLIC cxx_std_17)
 
 target_link_libraries(YARP_telemetry PUBLIC YARP::YARP_conf
                                             YARP::YARP_os
+                                            Boost::boost
                                      PRIVATE matioCpp::matioCpp)
 list(APPEND YARP_telemetry_PUBLIC_DEPS YARP_conf)
 

--- a/src/libYARP_telemetry/src/yarp/telemetry/Buffer.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/Buffer.h
@@ -11,7 +11,6 @@
 
 #include <yarp/telemetry/Record.h>
 #include <boost/circular_buffer.hpp>
-#include <matioCpp/matioCpp.h>
 #include <cstring>
 #include <vector>
 #include <memory>
@@ -66,6 +65,10 @@ public:
         return m_buffer_ptr->capacity() - m_buffer_ptr->size();
     }
 
+    size_t size() const {
+        return m_buffer_ptr->size();
+    }
+
     bool empty() const {
         return m_buffer_ptr->empty();
     }
@@ -90,12 +93,17 @@ public:
         return m_buffer_ptr->end();
     }
 
+    // TODO maybe this class has to be a struct??
     std::vector<size_t> getDimensions() const {
         return m_dimensions;
     }
 
     std::shared_ptr<boost::circular_buffer<Record<T>>> getBufferSharedPtr() const {
         return m_buffer_ptr;
+    }
+
+    std::string getVariableName() const {
+        return m_variable_name;
     }
 
 private:

--- a/src/libYARP_telemetry/src/yarp/telemetry/Buffer.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/Buffer.h
@@ -11,8 +11,10 @@
 
 #include <yarp/telemetry/Record.h>
 #include <boost/circular_buffer.hpp>
+#include <matioCpp/matioCpp.h>
 #include <cstring>
 #include <vector>
+#include <memory>
 
 namespace yarp::telemetry {
 
@@ -20,77 +22,86 @@ template<class T>
 class Buffer {
 public:
 
-using iterator       =  typename boost::circular_buffer<Record<T>>::iterator;
-using const_iterator =  typename boost::circular_buffer<Record<T>>::const_iterator;
+    using iterator       =  typename boost::circular_buffer<Record<T>>::iterator;
+    using const_iterator =  typename boost::circular_buffer<Record<T>>::const_iterator;
 
-Buffer() = delete;
+    Buffer() = delete;
 
-Buffer(const Buffer&) = default;
+    Buffer(const Buffer&) = default;
 
-Buffer(Buffer&&) noexcept = default;
+    Buffer(Buffer&&) noexcept = default;
 
-Buffer<T>& operator=(const Buffer<T>&) = default;
+    Buffer<T>& operator=(const Buffer<T>&) = default;
 
-Buffer<T>& operator=(Buffer<T>&&) noexcept = default;
+    Buffer<T>& operator=(Buffer<T>&&) noexcept = default;
 
-virtual ~Buffer() = default;
+    virtual ~Buffer() = default;
 
-Buffer(size_t num_elements,  const std::vector<size_t>& dimensions,
-       const std::string& name): m_buffer(num_elements), m_dimensions(dimensions), m_variable_name(name) {
+    Buffer(size_t num_elements,  const std::vector<size_t>& dimensions,
+        const std::string& name): m_buffer_ptr(std::make_shared<boost::circular_buffer<Record<T>>>(num_elements)),
+                                  m_dimensions(dimensions), m_variable_name(name) {
 
-}
+    }
 
-Buffer(size_t num_elements, const std::string& name): m_buffer(num_elements), m_variable_name(name) {
+    Buffer(size_t num_elements, const std::string& name): m_buffer_ptr(std::make_shared<boost::circular_buffer<Record<T>>>(num_elements)),
+                                                          m_variable_name(name) {
 
-}
+    }
 
-// TODO: enforced Record<T> ??
-// TODO: check if I am pushing a vector with the right dimensions
-inline void push_back(const Record<T> &elem)
-{
-    m_buffer.push_back(elem);
-}
+    // TODO: enforced Record<T> ??
+    // TODO: check if I am pushing a vector with the right dimensions
+    inline void push_back(const Record<T> &elem)
+    {
+        m_buffer_ptr->push_back(elem);
+    }
 
-// TODO: enforced Record<T> ??
-// TODO: check if I am pushing a vector with the right dimensions
-inline void push_back(Record<T>&& elem)
-{
-    m_buffer.push_back(std::move(elem));
-}
+    // TODO: enforced Record<T> ??
+    // TODO: check if I am pushing a vector with the right dimensions
+    inline void push_back(Record<T>&& elem)
+    {
+        m_buffer_ptr->push_back(std::move(elem));
+    }
 
-size_t getBufferFreeSpace() const {
-    return m_buffer.capacity() - m_buffer.size();
-}
+    size_t getBufferFreeSpace() const {
+        return m_buffer_ptr->capacity() - m_buffer_ptr->size();
+    }
 
-bool empty() const {
-    return m_buffer.empty();
-}
+    bool empty() const {
+        return m_buffer_ptr->empty();
+    }
 
-bool full() const {
-    return m_buffer.full();
-}
+    bool full() const {
+        return m_buffer_ptr->full();
+    }
 
-iterator begin() noexcept {
-    return m_buffer.begin();
-}
+    iterator begin() noexcept {
+        return m_buffer_ptr->begin();
+    }
 
-iterator end() noexcept {
-    return m_buffer.end();
-}
+    iterator end() noexcept {
+        return m_buffer_ptr->end();
+    }
 
-const_iterator begin() const noexcept {
-    return m_buffer.begin();
-}
+    const_iterator begin() const noexcept {
+        return m_buffer_ptr->begin();
+    }
 
-const_iterator end() const noexcept {
-    return m_buffer.end();
-}
+    const_iterator end() const noexcept {
+        return m_buffer_ptr->end();
+    }
 
+    std::vector<size_t> getDimensions() const {
+        return m_dimensions;
+    }
+
+    std::shared_ptr<boost::circular_buffer<Record<T>>> getBufferSharedPtr() const {
+        return m_buffer_ptr;
+    }
 
 private:
-boost::circular_buffer<Record<T>> m_buffer;
-std::vector<size_t> m_dimensions{1,1};
-std::string m_variable_name;
+    std::shared_ptr<boost::circular_buffer<Record<T>>> m_buffer_ptr;
+    std::vector<size_t> m_dimensions{1,1};
+    std::string m_variable_name;
 
 };
 

--- a/src/libYARP_telemetry/src/yarp/telemetry/Buffer.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/Buffer.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_TELEMETRY_BUFFER_H
+#define YARP_TELEMETRY_BUFFER_H
+
+#include <yarp/telemetry/Record.h>
+#include <boost/circular_buffer.hpp>
+#include <cstring>
+#include <vector>
+
+namespace yarp::telemetry {
+
+template<class T>
+class Buffer {
+public:
+
+using iterator       =  typename boost::circular_buffer<Record<T>>::iterator;
+using const_iterator =  typename boost::circular_buffer<Record<T>>::const_iterator;
+
+Buffer() = delete;
+
+Buffer(const Buffer&) = default;
+
+Buffer(Buffer&&) noexcept = default;
+
+Buffer<T>& operator=(const Buffer<T>&) = default;
+
+Buffer<T>& operator=(Buffer<T>&&) noexcept = default;
+
+virtual ~Buffer() = default;
+
+Buffer(size_t num_elements,  const std::vector<size_t>& dimensions,
+       const std::string& name): m_buffer(num_elements), m_dimensions(dimensions), m_variable_name(name) {
+
+}
+
+Buffer(size_t num_elements, const std::string& name): m_buffer(num_elements), m_variable_name(name) {
+
+}
+
+// TODO: enforced Record<T> ??
+// TODO: check if I am pushing a vector with the right dimensions
+inline void push_back(const Record<T> &elem)
+{
+    m_buffer.push_back(elem);
+}
+
+// TODO: enforced Record<T> ??
+// TODO: check if I am pushing a vector with the right dimensions
+inline void push_back(Record<T>&& elem)
+{
+    m_buffer.push_back(std::move(elem));
+}
+
+size_t getBufferFreeSpace() const {
+    return m_buffer.capacity() - m_buffer.size();
+}
+
+bool empty() const {
+    return m_buffer.empty();
+}
+
+bool full() const {
+    return m_buffer.full();
+}
+
+iterator begin() noexcept {
+    return m_buffer.begin();
+}
+
+iterator end() noexcept {
+    return m_buffer.end();
+}
+
+const_iterator begin() const noexcept {
+    return m_buffer.begin();
+}
+
+const_iterator end() const noexcept {
+    return m_buffer.end();
+}
+
+
+private:
+boost::circular_buffer<Record<T>> m_buffer;
+std::vector<size_t> m_dimensions{1,1};
+std::string m_variable_name;
+
+};
+
+
+} // yarp::telemetry
+
+#endif


### PR DESCRIPTION
I wrote down a first draft of the `yarp::telemetry::Buffer` API.
It is a template class that contains a `boost::circular_buffer<yarp::telemetry::Record<T>>`, a `std::string` that defines the name of the variable to be dumped, and a `vector<size_t>` defining the dimensionality of `T`.
I took inspiration from https://github.com/dic-iit/matio-cpp/blob/master/include/matioCpp/MultiDimensionalArray.h since the next step will be to use `matio-cpp` in order to dump the data.

I wrote also some utility functions, I have no idea if they can be useful or we need other functions I didn't add.

It fixes #6 