### PR TITLE
Add BufferManager API

### DIFF
--- a/src/examples/CB_to_matfile_example.cpp
+++ b/src/examples/CB_to_matfile_example.cpp
@@ -24,12 +24,12 @@ class storeData {
     bool closing;
     double period;
     double wait_interval;
-    vector<Record<vector<int> > > local_collection; // stores on the read-thread the values from the buffer
-    std::shared_ptr<boost::circular_buffer<Record<vector<int> > > >  cb; // shared pointer to circular buffer
+    vector<Record<int > > local_collection; // stores on the read-thread the values from the buffer
+    std::shared_ptr<boost::circular_buffer<Record<int > > >  cb; // shared pointer to circular buffer
   public:
 
     // constructor of the read/save class. Initialized with the shared pointer and the read period
-    storeData(std::shared_ptr<boost::circular_buffer<Record<vector<int> > > > _cb, const double& _period) : cb(_cb), period(_period) 
+    storeData(std::shared_ptr<boost::circular_buffer<Record<int > > > _cb, const double& _period) : cb(_cb), period(_period) 
     {
       closing = false;
     }
@@ -87,7 +87,7 @@ class storeData {
 
       // create copy of the local collection (this acts as a second buffer)
       lock_mut.lock();
-      vector<Record<vector<int> > > _collection_copy = local_collection;
+      vector<Record<int > > _collection_copy = local_collection;
       lock_mut.unlock();
       cout << "local copy created " << endl;
 
@@ -191,7 +191,7 @@ int main()
   /**************************************************/
 
   // Initialization of our Buffer (3 entries, type vector<int>)
-  Buffer<vector<int> > cb(3);
+  Buffer<int > cb(3);
   double period = 5; // period for the reading of the buffer
 
   // Initialization of our reading and saving to file class - uses the shared-pointer for reading the circular buffer

--- a/src/examples/CB_to_matfile_example.cpp
+++ b/src/examples/CB_to_matfile_example.cpp
@@ -114,7 +114,7 @@ class storeData {
         {
           linear_matrix.push_back(_el);
         }
-        timestamp_vector.push_back(_cell.m_ts.getTime());
+        timestamp_vector.push_back(_cell.m_ts);
       }
       cout << "matrix linearized " << endl;
 
@@ -191,7 +191,7 @@ int main()
   /**************************************************/
 
   // Initialization of our Buffer (3 entries, type vector<int>)
-  Buffer<vector<int> > cb(3, "data_cb");
+  Buffer<vector<int> > cb(3);
   double period = 5; // period for the reading of the buffer
 
   // Initialization of our reading and saving to file class - uses the shared-pointer for reading the circular buffer
@@ -207,7 +207,7 @@ int main()
 
     // we lock before we populate the circular buffer to prevent conflicts with reading
     lock_mut.lock();
-    cb.push_back(Record(Stamp(0, yarp::os::Time::now()), vec));
+    cb.push_back(Record(yarp::os::Time::now(), vec));
     lock_mut.unlock();
 
     // user input -> say "no" to close the loop and generate the mat file

--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -15,7 +15,7 @@ set(CB_TO_MATIO_EXAMPLE_SRC CB_to_matfile_example.cpp)
 
 
 add_executable(circular_buffer_example ${CIRCULAR_BUFFER_EXAMPLE_SRC})
-#add_executable(circular_buffer_record_example ${CIRCULAR_BUFFER_RECORD_EXAMPLE_SRC})
+add_executable(circular_buffer_record_example ${CIRCULAR_BUFFER_RECORD_EXAMPLE_SRC})
 add_executable(matio_vector_example ${MATIO_VECTOR_EXAMPLE_SRC})
 add_executable(matio_matrix_example ${MATIO_MATRIX_EXAMPLE_SRC})
 add_executable(matio_timeseries_example ${MATIO_TIMESERIES_EXAMPLE_SRC})
@@ -24,17 +24,17 @@ add_executable(telemetry_buffer_manager_example ${TELEMETRY_BUFFER_MANAGER_EXAMP
 #add_executable(CB_to_matfile_example ${CB_TO_MATIO_EXAMPLE_SRC})
 
 target_compile_features(circular_buffer_example PUBLIC cxx_std_14)
-#target_compile_features(circular_buffer_record_example PUBLIC cxx_std_14)
+target_compile_features(circular_buffer_record_example PUBLIC cxx_std_14)
 #target_compile_features(telemetry_buffer_example PUBLIC cxx_std_14)
 target_compile_features(telemetry_buffer_manager_example PUBLIC cxx_std_14)
 
 
 target_link_libraries(circular_buffer_example Boost::boost)
-#target_link_libraries(circular_buffer_record_example Boost::boost
-#                                                     YARP::YARP_conf
-#                                                     YARP::YARP_os
-#                                                     YARP::YARP_init
-#                                                     YARP::YARP_telemetry)
+target_link_libraries(circular_buffer_record_example Boost::boost
+                                                     YARP::YARP_conf
+                                                     YARP::YARP_os
+                                                     YARP::YARP_init
+                                                     YARP::YARP_telemetry)
 #target_link_libraries(telemetry_buffer_example YARP::YARP_conf
 #                                               YARP::YARP_os
 #                                               YARP::YARP_init

--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -10,37 +10,45 @@ set(MATIO_VECTOR_EXAMPLE_SRC matio_vector_example.cpp)
 set(MATIO_MATRIX_EXAMPLE_SRC matio_matrix_example.cpp)
 set(MATIO_TIMESERIES_EXAMPLE_SRC matio_timeseries_example.cpp)
 set(TELEMETRY_BUFFER_EXAMPLE_SRC telemetry_buffer_example.cpp)
+set(TELEMETRY_BUFFER_MANAGER_EXAMPLE_SRC telemetry_buffer_manager_example.cpp)
 set(CB_TO_MATIO_EXAMPLE_SRC CB_to_matfile_example.cpp)
 
 
 add_executable(circular_buffer_example ${CIRCULAR_BUFFER_EXAMPLE_SRC})
-add_executable(circular_buffer_record_example ${CIRCULAR_BUFFER_RECORD_EXAMPLE_SRC})
+#add_executable(circular_buffer_record_example ${CIRCULAR_BUFFER_RECORD_EXAMPLE_SRC})
 add_executable(matio_vector_example ${MATIO_VECTOR_EXAMPLE_SRC})
 add_executable(matio_matrix_example ${MATIO_MATRIX_EXAMPLE_SRC})
 add_executable(matio_timeseries_example ${MATIO_TIMESERIES_EXAMPLE_SRC})
-add_executable(telemetry_buffer_example ${TELEMETRY_BUFFER_EXAMPLE_SRC})
-add_executable(CB_to_matfile_example ${CB_TO_MATIO_EXAMPLE_SRC})
+#add_executable(telemetry_buffer_example ${TELEMETRY_BUFFER_EXAMPLE_SRC})
+add_executable(telemetry_buffer_manager_example ${TELEMETRY_BUFFER_MANAGER_EXAMPLE_SRC})
+#add_executable(CB_to_matfile_example ${CB_TO_MATIO_EXAMPLE_SRC})
 
 target_compile_features(circular_buffer_example PUBLIC cxx_std_14)
-target_compile_features(circular_buffer_record_example PUBLIC cxx_std_14)
-target_compile_features(telemetry_buffer_example PUBLIC cxx_std_14)
+#target_compile_features(circular_buffer_record_example PUBLIC cxx_std_14)
+#target_compile_features(telemetry_buffer_example PUBLIC cxx_std_14)
+target_compile_features(telemetry_buffer_manager_example PUBLIC cxx_std_14)
+
 
 target_link_libraries(circular_buffer_example Boost::boost)
-target_link_libraries(circular_buffer_record_example Boost::boost
-                                                     YARP::YARP_conf
-                                                     YARP::YARP_os
-                                                     YARP::YARP_init
-                                                     YARP::YARP_telemetry)
-target_link_libraries(telemetry_buffer_example YARP::YARP_conf
-                                               YARP::YARP_os
-                                               YARP::YARP_init
-                                               YARP::YARP_telemetry)
+#target_link_libraries(circular_buffer_record_example Boost::boost
+#                                                     YARP::YARP_conf
+#                                                     YARP::YARP_os
+#                                                     YARP::YARP_init
+#                                                     YARP::YARP_telemetry)
+#target_link_libraries(telemetry_buffer_example YARP::YARP_conf
+#                                               YARP::YARP_os
+#                                               YARP::YARP_init
+#                                               YARP::YARP_telemetry)
+target_link_libraries(telemetry_buffer_manager_example YARP::YARP_conf
+                                                       YARP::YARP_os
+                                                       YARP::YARP_init
+                                                       YARP::YARP_telemetry)
 target_link_libraries(matio_vector_example PRIVATE matioCpp::matioCpp)
 target_link_libraries(matio_matrix_example PRIVATE matioCpp::matioCpp)
 target_link_libraries(matio_timeseries_example PRIVATE matioCpp::matioCpp)
-target_link_libraries(CB_to_matfile_example PRIVATE matioCpp::matioCpp 
-                                                Boost::boost 
-                                                YARP::YARP_telemetry
-                                                YARP::YARP_conf
-                                                YARP::YARP_os
-                                                YARP::YARP_init ${CMAKE_THREAD_LIBS_INIT})
+#target_link_libraries(CB_to_matfile_example PRIVATE matioCpp::matioCpp 
+#                                                Boost::boost 
+#                                                YARP::YARP_telemetry
+#                                                YARP::YARP_conf
+#                                                YARP::YARP_os
+#                                                YARP::YARP_init ${CMAKE_THREAD_LIBS_INIT})

--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -19,13 +19,13 @@ add_executable(circular_buffer_record_example ${CIRCULAR_BUFFER_RECORD_EXAMPLE_S
 add_executable(matio_vector_example ${MATIO_VECTOR_EXAMPLE_SRC})
 add_executable(matio_matrix_example ${MATIO_MATRIX_EXAMPLE_SRC})
 add_executable(matio_timeseries_example ${MATIO_TIMESERIES_EXAMPLE_SRC})
-#add_executable(telemetry_buffer_example ${TELEMETRY_BUFFER_EXAMPLE_SRC})
+add_executable(telemetry_buffer_example ${TELEMETRY_BUFFER_EXAMPLE_SRC})
 add_executable(telemetry_buffer_manager_example ${TELEMETRY_BUFFER_MANAGER_EXAMPLE_SRC})
 #add_executable(CB_to_matfile_example ${CB_TO_MATIO_EXAMPLE_SRC})
 
 target_compile_features(circular_buffer_example PUBLIC cxx_std_14)
 target_compile_features(circular_buffer_record_example PUBLIC cxx_std_14)
-#target_compile_features(telemetry_buffer_example PUBLIC cxx_std_14)
+target_compile_features(telemetry_buffer_example PUBLIC cxx_std_14)
 target_compile_features(telemetry_buffer_manager_example PUBLIC cxx_std_14)
 
 
@@ -35,10 +35,10 @@ target_link_libraries(circular_buffer_record_example Boost::boost
                                                      YARP::YARP_os
                                                      YARP::YARP_init
                                                      YARP::YARP_telemetry)
-#target_link_libraries(telemetry_buffer_example YARP::YARP_conf
-#                                               YARP::YARP_os
-#                                               YARP::YARP_init
-#                                               YARP::YARP_telemetry)
+target_link_libraries(telemetry_buffer_example YARP::YARP_conf
+                                               YARP::YARP_os
+                                               YARP::YARP_init
+                                               YARP::YARP_telemetry)
 target_link_libraries(telemetry_buffer_manager_example YARP::YARP_conf
                                                        YARP::YARP_os
                                                        YARP::YARP_init

--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -21,7 +21,7 @@ add_executable(matio_matrix_example ${MATIO_MATRIX_EXAMPLE_SRC})
 add_executable(matio_timeseries_example ${MATIO_TIMESERIES_EXAMPLE_SRC})
 add_executable(telemetry_buffer_example ${TELEMETRY_BUFFER_EXAMPLE_SRC})
 add_executable(telemetry_buffer_manager_example ${TELEMETRY_BUFFER_MANAGER_EXAMPLE_SRC})
-#add_executable(CB_to_matfile_example ${CB_TO_MATIO_EXAMPLE_SRC})
+add_executable(CB_to_matfile_example ${CB_TO_MATIO_EXAMPLE_SRC})
 
 target_compile_features(circular_buffer_example PUBLIC cxx_std_14)
 target_compile_features(circular_buffer_record_example PUBLIC cxx_std_14)
@@ -46,9 +46,9 @@ target_link_libraries(telemetry_buffer_manager_example YARP::YARP_conf
 target_link_libraries(matio_vector_example PRIVATE matioCpp::matioCpp)
 target_link_libraries(matio_matrix_example PRIVATE matioCpp::matioCpp)
 target_link_libraries(matio_timeseries_example PRIVATE matioCpp::matioCpp)
-#target_link_libraries(CB_to_matfile_example PRIVATE matioCpp::matioCpp 
-#                                                Boost::boost 
-#                                                YARP::YARP_telemetry
-#                                                YARP::YARP_conf
-#                                                YARP::YARP_os
-#                                                YARP::YARP_init ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(CB_to_matfile_example PRIVATE matioCpp::matioCpp 
+                                                Boost::boost 
+                                                YARP::YARP_telemetry
+                                                YARP::YARP_conf
+                                                YARP::YARP_os
+                                                YARP::YARP_init ${CMAKE_THREAD_LIBS_INIT})

--- a/src/examples/circular_buffer_record_example.cpp
+++ b/src/examples/circular_buffer_record_example.cpp
@@ -30,26 +30,25 @@ using namespace yarp::telemetry;
     // Create a circular buffer with a capacity for 3 Record<int32_t> structures.
     boost::circular_buffer<yarp::telemetry::Record<int32_t>> cb_i(3);
 
-    auto count = 0;
     auto total_payload = 0;
     cout<<"The capacity is: "<<cb_i.capacity()<<" and the size is: "<<cb_i.size()<<std::endl;
     // Insert threee elements into the buffer.
-    cb_i.push_back(Record(Stamp(count++, yarp::os::Time::now()), 1));
+    cb_i.push_back(Record(yarp::os::Time::now(), 1));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    cb_i.push_back(Record(Stamp(count++, yarp::os::Time::now()), 2));
+    cb_i.push_back(Record(yarp::os::Time::now(), 2));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    cb_i.push_back(Record(Stamp(count++, yarp::os::Time::now()), 3));
+    cb_i.push_back(Record(yarp::os::Time::now(), 3));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
     cout<<"The capacity is: "<<cb_i.capacity()<<" and the size is: "<<cb_i.size()<<std::endl;
     cout<<"The circular buffer contains:"<<endl;
     for (auto& c_el : cb_i) {
-        cout<<c_el.m_ts.getCount() << " " << std::setw( 14 ) << std::setprecision( 14 ) << c_el.m_ts.getTime() << " | " << c_el.m_datum<<std::endl;
+        cout<<std::setw( 14 ) << std::setprecision( 14 ) << c_el.m_ts << " | " << c_el.m_datum<<std::endl;
     }
 
-    cb_i.push_back(Record(Stamp(count++, yarp::os::Time::now()), 4));
+    cb_i.push_back(Record(yarp::os::Time::now(), 4));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    cb_i.push_back(Record(Stamp(count++, yarp::os::Time::now()), 5));
+    cb_i.push_back(Record(yarp::os::Time::now(), 5));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
 
@@ -57,7 +56,7 @@ using namespace yarp::telemetry;
     cout<<"The circular buffer contains:"<<endl;
     for (auto& c_el : cb_i) {
         total_payload += c_el.getPayload();
-        cout<<c_el.m_ts.getCount() << " " << std::setw( 14 ) << std::setprecision( 14 ) << c_el.m_ts.getTime() << " | " << c_el.m_datum<<std::endl;
+        cout<<std::setw( 14 ) << std::setprecision( 14 ) << c_el.m_ts << " | " << c_el.m_datum<<std::endl;
     }
 
     std::cout<<"The circular buffer payload is "<<total_payload<<" bytes "<<std::endl;
@@ -67,26 +66,25 @@ using namespace yarp::telemetry;
     // Create a circular buffer with a capacity for 3 Record<double> structures.
     boost::circular_buffer<yarp::telemetry::Record<double>> cb_d(3);
 
-    count = 0;
     total_payload = 0;
     cout<<"The capacity is: "<<cb_d.capacity()<<" and the size is: "<<cb_d.size()<<std::endl;
     // Insert threee elements into the buffer.
-    cb_d.push_back(Record(Stamp(count++, yarp::os::Time::now()), 0.1));
+    cb_d.push_back(Record(yarp::os::Time::now(), 0.1));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    cb_d.push_back(Record(Stamp(count++, yarp::os::Time::now()), 0.2));
+    cb_d.push_back(Record(yarp::os::Time::now(), 0.2));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    cb_d.push_back(Record(Stamp(count++, yarp::os::Time::now()), 0.3));
+    cb_d.push_back(Record(yarp::os::Time::now(), 0.3));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
     cout<<"The capacity is: "<<cb_d.capacity()<<" and the size is: "<<cb_d.size()<<std::endl;
     cout<<"The circular buffer contains:"<<endl;
     for (auto& c_el : cb_d) {
-        cout<<c_el.m_ts.getCount() << " " << std::setw( 14 ) << std::setprecision( 14 ) << c_el.m_ts.getTime() << " | " << c_el.m_datum<<std::endl;
+        cout<< std::setw( 14 ) << std::setprecision( 14 ) << c_el.m_ts << " | " << c_el.m_datum<<std::endl;
     }
 
-    cb_d.push_back(Record(Stamp(count++, yarp::os::Time::now()), 0.4));
+    cb_d.push_back(Record(yarp::os::Time::now(), 0.4));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    cb_d.push_back(Record(Stamp(count++, yarp::os::Time::now()), 0.5));
+    cb_d.push_back(Record(yarp::os::Time::now(), 0.5));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
 
@@ -94,7 +92,7 @@ using namespace yarp::telemetry;
     cout<<"The circular buffer contains:"<<endl;
     for (auto& c_el : cb_d) {
         total_payload += c_el.getPayload();
-        cout<<c_el.m_ts.getCount() << " " << std::setw( 14 ) << std::setprecision( 14 ) << c_el.m_ts.getTime() << " | " << c_el.m_datum<<std::endl;
+        cout<< std::setw( 14 ) << std::setprecision( 14 ) << c_el.m_ts<< " | " << c_el.m_datum<<std::endl;
     }
 
     std::cout<<"The circular buffer payload is "<<total_payload<<" bytes "<<std::endl;
@@ -103,21 +101,20 @@ using namespace yarp::telemetry;
     // Create a circular buffer with a capacity for 3 Record<vector<double>> structures.
     boost::circular_buffer<yarp::telemetry::Record<vector<double>>> cb_v(3);
 
-    count = 0;
     total_payload = 0;
     cout<<"The capacity is: "<<cb_v.capacity()<<" and the size is: "<<cb_v.size()<<std::endl;
     // Insert threee elements into the buffer.
-    cb_v.push_back(Record(Stamp(count++, yarp::os::Time::now()), vector<double>{0.1, 0.2, 0.3}));
+    cb_v.push_back(Record(yarp::os::Time::now(), vector<double>{0.1, 0.2, 0.3}));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    cb_v.push_back(Record(Stamp(count++, yarp::os::Time::now()), vector<double>{0.3, 0.4, 0.5}));
+    cb_v.push_back(Record(yarp::os::Time::now(), vector<double>{0.3, 0.4, 0.5}));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    cb_v.push_back(Record(Stamp(count++, yarp::os::Time::now()), vector<double>{0.6, 0.7, 0.8}));
+    cb_v.push_back(Record(yarp::os::Time::now(), vector<double>{0.6, 0.7, 0.8}));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
     cout<<"The capacity is: "<<cb_v.capacity()<<" and the size is: "<<cb_v.size()<<std::endl;
     cout<<"The circular buffer contains:"<<endl;
     for (auto& c_el : cb_v) {
-        cout<<c_el.m_ts.getCount() << " " << std::setw( 14 ) << std::setprecision( 14 ) << c_el.m_ts.getTime() << " | " ;
+        cout<<std::setw( 14 ) << std::setprecision( 14 ) << c_el.m_ts<< " | " ;
         for(const auto& v_el : c_el.m_datum)
         {
              cout<<v_el<<" ";
@@ -125,9 +122,9 @@ using namespace yarp::telemetry;
         cout<<std::endl;
     }
 
-    cb_v.push_back(Record(Stamp(count++, yarp::os::Time::now()), vector<double>{0.9, 1.0, 1.1}));
+    cb_v.push_back(Record(yarp::os::Time::now(), vector<double>{0.9, 1.0, 1.1}));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    cb_v.push_back(Record(Stamp(count++, yarp::os::Time::now()), vector<double>{1.2, 1.3, 1.4}));
+    cb_v.push_back(Record(yarp::os::Time::now(), vector<double>{1.2, 1.3, 1.4}));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
 
@@ -135,7 +132,7 @@ using namespace yarp::telemetry;
     cout<<"The circular buffer contains:"<<endl;
     for (auto& c_el : cb_v) {
         total_payload += c_el.getPayload();
-        cout<<c_el.m_ts.getCount() << " " << std::setw( 14 ) << std::setprecision( 14 ) << c_el.m_ts.getTime() << " | " ;
+        cout<< std::setw( 14 ) << std::setprecision( 14 ) << c_el.m_ts << " | " ;
         for(const auto& v_el : c_el.m_datum)
         {
              cout<<v_el<<" ";

--- a/src/examples/circular_buffer_record_example.cpp
+++ b/src/examples/circular_buffer_record_example.cpp
@@ -33,22 +33,22 @@ using namespace yarp::telemetry;
     auto total_payload = 0;
     cout<<"The capacity is: "<<cb_i.capacity()<<" and the size is: "<<cb_i.size()<<std::endl;
     // Insert threee elements into the buffer.
-    cb_i.push_back(Record(yarp::os::Time::now(), 1));
+    cb_i.push_back(Record(yarp::os::Time::now(), vector<int32_t>{ 1 }));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    cb_i.push_back(Record(yarp::os::Time::now(), 2));
+    cb_i.push_back(Record(yarp::os::Time::now(), vector<int32_t>{ 2 }));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    cb_i.push_back(Record(yarp::os::Time::now(), 3));
+    cb_i.push_back(Record(yarp::os::Time::now(), vector<int32_t>{ 3 }));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
     cout<<"The capacity is: "<<cb_i.capacity()<<" and the size is: "<<cb_i.size()<<std::endl;
     cout<<"The circular buffer contains:"<<endl;
     for (auto& c_el : cb_i) {
-        cout<<std::setw( 14 ) << std::setprecision( 14 ) << c_el.m_ts << " | " << c_el.m_datum<<std::endl;
+        cout<<std::setw( 14 ) << std::setprecision( 14 ) << c_el.m_ts << " | " << c_el.m_datum[0]<<std::endl;
     }
 
-    cb_i.push_back(Record(yarp::os::Time::now(), 4));
+    cb_i.push_back(Record(yarp::os::Time::now(), vector<int32_t>{ 4 }));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    cb_i.push_back(Record(yarp::os::Time::now(), 5));
+    cb_i.push_back(Record(yarp::os::Time::now(), vector<int32_t>{ 5 }));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
 
@@ -56,7 +56,7 @@ using namespace yarp::telemetry;
     cout<<"The circular buffer contains:"<<endl;
     for (auto& c_el : cb_i) {
         total_payload += c_el.getPayload();
-        cout<<std::setw( 14 ) << std::setprecision( 14 ) << c_el.m_ts << " | " << c_el.m_datum<<std::endl;
+        cout<<std::setw( 14 ) << std::setprecision( 14 ) << c_el.m_ts << " | " << c_el.m_datum[0]<<std::endl;
     }
 
     std::cout<<"The circular buffer payload is "<<total_payload<<" bytes "<<std::endl;
@@ -69,22 +69,22 @@ using namespace yarp::telemetry;
     total_payload = 0;
     cout<<"The capacity is: "<<cb_d.capacity()<<" and the size is: "<<cb_d.size()<<std::endl;
     // Insert threee elements into the buffer.
-    cb_d.push_back(Record(yarp::os::Time::now(), 0.1));
+    cb_d.push_back(Record(yarp::os::Time::now(), vector<double>{ 0.1 }));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    cb_d.push_back(Record(yarp::os::Time::now(), 0.2));
+    cb_d.push_back(Record(yarp::os::Time::now(), vector<double>{ 0.2 }));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    cb_d.push_back(Record(yarp::os::Time::now(), 0.3));
+    cb_d.push_back(Record(yarp::os::Time::now(), vector<double>{ 0.3 }));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
     cout<<"The capacity is: "<<cb_d.capacity()<<" and the size is: "<<cb_d.size()<<std::endl;
     cout<<"The circular buffer contains:"<<endl;
     for (auto& c_el : cb_d) {
-        cout<< std::setw( 14 ) << std::setprecision( 14 ) << c_el.m_ts << " | " << c_el.m_datum<<std::endl;
+        cout<< std::setw( 14 ) << std::setprecision( 14 ) << c_el.m_ts << " | " << c_el.m_datum[0]<<std::endl;
     }
 
-    cb_d.push_back(Record(yarp::os::Time::now(), 0.4));
+    cb_d.push_back(Record(yarp::os::Time::now(), vector<double>{ 0.4 }));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    cb_d.push_back(Record(yarp::os::Time::now(), 0.5));
+    cb_d.push_back(Record(yarp::os::Time::now(), vector<double>{ 0.5 }));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
 
@@ -92,14 +92,14 @@ using namespace yarp::telemetry;
     cout<<"The circular buffer contains:"<<endl;
     for (auto& c_el : cb_d) {
         total_payload += c_el.getPayload();
-        cout<< std::setw( 14 ) << std::setprecision( 14 ) << c_el.m_ts<< " | " << c_el.m_datum<<std::endl;
+        cout<< std::setw( 14 ) << std::setprecision( 14 ) << c_el.m_ts<< " | " << c_el.m_datum[0]<<std::endl;
     }
 
     std::cout<<"The circular buffer payload is "<<total_payload<<" bytes "<<std::endl;
     std::cout<<"XXXXXXXX CIRCULAR BUFFER OF VECTOR OF DOUBLE XXXXXXXX"<<std::endl;
 
     // Create a circular buffer with a capacity for 3 Record<vector<double>> structures.
-    boost::circular_buffer<yarp::telemetry::Record<vector<double>>> cb_v(3);
+    boost::circular_buffer<yarp::telemetry::Record<double>> cb_v(3);
 
     total_payload = 0;
     cout<<"The capacity is: "<<cb_v.capacity()<<" and the size is: "<<cb_v.size()<<std::endl;

--- a/src/examples/telemetry_buffer_example.cpp
+++ b/src/examples/telemetry_buffer_example.cpp
@@ -30,29 +30,29 @@ using namespace yarp::telemetry;
 
     cout<<"The space available is: "<<cb_i.getBufferFreeSpace()<<std::endl;
     // Insert threee elements into the buffer.
-    cb_i.push_back(Record(yarp::os::Time::now(), 1));
+    cb_i.push_back(Record(yarp::os::Time::now(), vector<int32_t>{ 1 }));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    cb_i.push_back(Record(yarp::os::Time::now(), 2));
+    cb_i.push_back(Record(yarp::os::Time::now(), vector<int32_t>{ 2 }));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    cb_i.push_back(Record(yarp::os::Time::now(), 3));
+    cb_i.push_back(Record(yarp::os::Time::now(), vector<int32_t>{ 3 }));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
     cout<<"The space available is: "<<cb_i.getBufferFreeSpace()<<std::endl;
     cout<<"The circular buffer contains:"<<endl;
     for (auto& c_el : cb_i) {
-        cout<<std::setw( 14 ) << std::setprecision( 14 ) << c_el.m_ts<< " | " << c_el.m_datum<<std::endl;
+        cout<<std::setw( 14 ) << std::setprecision( 14 ) << c_el.m_ts<< " | " << c_el.m_datum[0]<<std::endl;
     }
 
-    cb_i.push_back(Record(yarp::os::Time::now(), 4));
+    cb_i.push_back(Record(yarp::os::Time::now(), vector<int32_t>{ 4 }));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    cb_i.push_back(Record(yarp::os::Time::now(), 5));
+    cb_i.push_back(Record(yarp::os::Time::now(), vector<int32_t>{ 5 }));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
 
     cout<<"The space available is: "<<cb_i.getBufferFreeSpace()<<std::endl;
     cout<<"The circular buffer contains:"<<endl;
     for (auto& c_el : cb_i) {
-        cout<< " " << std::setw( 14 ) << std::setprecision( 14 ) << c_el.m_ts<< " | " << c_el.m_datum<<std::endl;
+        cout<< " " << std::setw( 14 ) << std::setprecision( 14 ) << c_el.m_ts<< " | " << c_el.m_datum[0]<<std::endl;
     }
 
 
@@ -62,34 +62,34 @@ using namespace yarp::telemetry;
 
     cout<<"The space available is: "<<cb_d.getBufferFreeSpace()<<std::endl;
     // Insert threee elements into the buffer.
-    cb_d.push_back(Record(yarp::os::Time::now(), 0.1));
+    cb_d.push_back(Record(yarp::os::Time::now(), vector<double>{ 0.1 }));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    cb_d.push_back(Record(yarp::os::Time::now(), 0.2));
+    cb_d.push_back(Record(yarp::os::Time::now(), vector<double>{ 0.2 }));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    cb_d.push_back(Record(yarp::os::Time::now(), 0.3));
+    cb_d.push_back(Record(yarp::os::Time::now(), vector<double>{ 0.3 }));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
     cout<<"The space available is: "<<cb_d.getBufferFreeSpace()<<std::endl;
     cout<<"The circular buffer contains:"<<endl;
     for (auto& c_el : cb_d) {
-        cout<< " " << std::setw( 14 ) << std::setprecision( 14 ) << c_el.m_ts<< " | " << c_el.m_datum<<std::endl;
+        cout<< " " << std::setw( 14 ) << std::setprecision( 14 ) << c_el.m_ts<< " | " << c_el.m_datum[0]<<std::endl;
     }
 
-    cb_d.push_back(Record(yarp::os::Time::now(), 0.4));
+    cb_d.push_back(Record(yarp::os::Time::now(), vector<double>{ 0.4 }));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    cb_d.push_back(Record(yarp::os::Time::now(), 0.5));
+    cb_d.push_back(Record(yarp::os::Time::now(), vector<double>{ 0.5 }));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
 
     cout<<"The space available is: "<<cb_d.getBufferFreeSpace()<<std::endl;
     cout<<"The circular buffer contains:"<<endl;
     for (auto& c_el : cb_d) {
-        cout<< std::setw( 14 ) << std::setprecision( 14 ) << c_el.m_ts << " | " << c_el.m_datum<<std::endl;
+        cout<< std::setw( 14 ) << std::setprecision( 14 ) << c_el.m_ts << " | " << c_el.m_datum[0]<<std::endl;
     }
 
     std::cout<<"XXXXXXXX TELEMETRY BUFFER OF VECTOR OF DOUBLE XXXXXXXX"<<std::endl;
 
-    yarp::telemetry::Buffer<vector<double>> cb_v(3);
+    yarp::telemetry::Buffer<double> cb_v(3);
 
     cout<<"The space available is: "<<cb_v.getBufferFreeSpace()<<std::endl;
     // Insert threee elements into the buffer.

--- a/src/examples/telemetry_buffer_example.cpp
+++ b/src/examples/telemetry_buffer_example.cpp
@@ -26,86 +26,84 @@ using namespace yarp::telemetry;
     Network yarp;
 
     std::cout<<"XXXXXXXX TELEMETRY BUFFER OF INT XXXXXXXX"<<std::endl;
-    yarp::telemetry::Buffer<int32_t> cb_i(3, {1,1}, "buffer_int32_t");
+    yarp::telemetry::Buffer<int32_t> cb_i(3);
 
-    auto count = 0;
     cout<<"The space available is: "<<cb_i.getBufferFreeSpace()<<std::endl;
     // Insert threee elements into the buffer.
-    cb_i.push_back(Record(Stamp(count++, yarp::os::Time::now()), 1));
+    cb_i.push_back(Record(yarp::os::Time::now(), 1));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    cb_i.push_back(Record(Stamp(count++, yarp::os::Time::now()), 2));
+    cb_i.push_back(Record(yarp::os::Time::now(), 2));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    cb_i.push_back(Record(Stamp(count++, yarp::os::Time::now()), 3));
+    cb_i.push_back(Record(yarp::os::Time::now(), 3));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
     cout<<"The space available is: "<<cb_i.getBufferFreeSpace()<<std::endl;
     cout<<"The circular buffer contains:"<<endl;
     for (auto& c_el : cb_i) {
-        cout<<c_el.m_ts.getCount() << " " << std::setw( 14 ) << std::setprecision( 14 ) << c_el.m_ts.getTime() << " | " << c_el.m_datum<<std::endl;
+        cout<<std::setw( 14 ) << std::setprecision( 14 ) << c_el.m_ts<< " | " << c_el.m_datum<<std::endl;
     }
 
-    cb_i.push_back(Record(Stamp(count++, yarp::os::Time::now()), 4));
+    cb_i.push_back(Record(yarp::os::Time::now(), 4));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    cb_i.push_back(Record(Stamp(count++, yarp::os::Time::now()), 5));
+    cb_i.push_back(Record(yarp::os::Time::now(), 5));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
 
     cout<<"The space available is: "<<cb_i.getBufferFreeSpace()<<std::endl;
     cout<<"The circular buffer contains:"<<endl;
     for (auto& c_el : cb_i) {
-        cout<<c_el.m_ts.getCount() << " " << std::setw( 14 ) << std::setprecision( 14 ) << c_el.m_ts.getTime() << " | " << c_el.m_datum<<std::endl;
+        cout<< " " << std::setw( 14 ) << std::setprecision( 14 ) << c_el.m_ts<< " | " << c_el.m_datum<<std::endl;
     }
 
 
     std::cout<<"XXXXXXXX TELEMETRY BUFFER OF DOUBLE XXXXXXXX"<<std::endl;
 
-    yarp::telemetry::Buffer<double> cb_d(3, "buffer_double");
+    yarp::telemetry::Buffer<double> cb_d(3);
 
-    count = 0;
     cout<<"The space available is: "<<cb_d.getBufferFreeSpace()<<std::endl;
     // Insert threee elements into the buffer.
-    cb_d.push_back(Record(Stamp(count++, yarp::os::Time::now()), 0.1));
+    cb_d.push_back(Record(yarp::os::Time::now(), 0.1));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    cb_d.push_back(Record(Stamp(count++, yarp::os::Time::now()), 0.2));
+    cb_d.push_back(Record(yarp::os::Time::now(), 0.2));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    cb_d.push_back(Record(Stamp(count++, yarp::os::Time::now()), 0.3));
+    cb_d.push_back(Record(yarp::os::Time::now(), 0.3));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
     cout<<"The space available is: "<<cb_d.getBufferFreeSpace()<<std::endl;
     cout<<"The circular buffer contains:"<<endl;
     for (auto& c_el : cb_d) {
-        cout<<c_el.m_ts.getCount() << " " << std::setw( 14 ) << std::setprecision( 14 ) << c_el.m_ts.getTime() << " | " << c_el.m_datum<<std::endl;
+        cout<< " " << std::setw( 14 ) << std::setprecision( 14 ) << c_el.m_ts<< " | " << c_el.m_datum<<std::endl;
     }
 
-    cb_d.push_back(Record(Stamp(count++, yarp::os::Time::now()), 0.4));
+    cb_d.push_back(Record(yarp::os::Time::now(), 0.4));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    cb_d.push_back(Record(Stamp(count++, yarp::os::Time::now()), 0.5));
+    cb_d.push_back(Record(yarp::os::Time::now(), 0.5));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
 
     cout<<"The space available is: "<<cb_d.getBufferFreeSpace()<<std::endl;
     cout<<"The circular buffer contains:"<<endl;
     for (auto& c_el : cb_d) {
-        cout<<c_el.m_ts.getCount() << " " << std::setw( 14 ) << std::setprecision( 14 ) << c_el.m_ts.getTime() << " | " << c_el.m_datum<<std::endl;
+        cout<< std::setw( 14 ) << std::setprecision( 14 ) << c_el.m_ts << " | " << c_el.m_datum<<std::endl;
     }
 
     std::cout<<"XXXXXXXX TELEMETRY BUFFER OF VECTOR OF DOUBLE XXXXXXXX"<<std::endl;
 
-    yarp::telemetry::Buffer<vector<double>> cb_v(3,{3,1}, "buffer_int32_t");
+    yarp::telemetry::Buffer<vector<double>> cb_v(3);
 
     cout<<"The space available is: "<<cb_v.getBufferFreeSpace()<<std::endl;
     // Insert threee elements into the buffer.
-    cb_v.push_back(Record(Stamp(count++, yarp::os::Time::now()), vector<double>{0.1, 0.2, 0.3}));
+    cb_v.push_back(Record(yarp::os::Time::now(), vector<double>{0.1, 0.2, 0.3}));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    cb_v.push_back(Record(Stamp(count++, yarp::os::Time::now()), vector<double>{0.3, 0.4, 0.5}));
+    cb_v.push_back(Record(yarp::os::Time::now(), vector<double>{0.3, 0.4, 0.5}));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    cb_v.push_back(Record(Stamp(count++, yarp::os::Time::now()), vector<double>{0.6, 0.7, 0.8}));
+    cb_v.push_back(Record(yarp::os::Time::now(), vector<double>{0.6, 0.7, 0.8}));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
     cout<<"The space available is: "<<cb_v.getBufferFreeSpace()<<std::endl;
     cout<<"The circular buffer contains:"<<endl;
     for (auto& c_el : cb_v) {
-        cout<<c_el.m_ts.getCount() << " " << std::setw( 14 ) << std::setprecision( 14 ) << c_el.m_ts.getTime() << " | " ;
+        cout<< " " << std::setw( 14 ) << std::setprecision( 14 ) << c_el.m_ts << " | " ;
         for(const auto& v_el : c_el.m_datum)
         {
              cout<<v_el<<" ";
@@ -113,16 +111,16 @@ using namespace yarp::telemetry;
         cout<<std::endl;
     }
 
-    cb_v.push_back(Record(Stamp(count++, yarp::os::Time::now()), vector<double>{0.9, 1.0, 1.1}));
+    cb_v.push_back(Record(yarp::os::Time::now(), vector<double>{0.9, 1.0, 1.1}));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    cb_v.push_back(Record(Stamp(count++, yarp::os::Time::now()), vector<double>{1.2, 1.3, 1.4}));
+    cb_v.push_back(Record(yarp::os::Time::now(), vector<double>{1.2, 1.3, 1.4}));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
 
     cout<<"The space available is: "<<cb_v.getBufferFreeSpace()<<std::endl;
     cout<<"The circular buffer contains:"<<endl;
     for (auto& c_el : cb_v) {
-        cout<<c_el.m_ts.getCount() << " " << std::setw( 14 ) << std::setprecision( 14 ) << c_el.m_ts.getTime() << " | " ;
+        cout<< std::setw( 14 ) << std::setprecision( 14 ) << c_el.m_ts << " | " ;
         for(const auto& v_el : c_el.m_datum)
         {
              cout<<v_el<<" ";

--- a/src/examples/telemetry_buffer_manager_example.cpp
+++ b/src/examples/telemetry_buffer_manager_example.cpp
@@ -48,7 +48,6 @@ using namespace yarp::telemetry;
         bm_v.push_back({ (double)i, i*2.0, i*3.0, i*4.0 }, "two");
     }
 
-    // ISSUES HERE
     if (bm_v.saveToFile("buffer_manager_test_vector.mat"))
         std::cout << "File saved correctly!" << std::endl;
     else

--- a/src/examples/telemetry_buffer_manager_example.cpp
+++ b/src/examples/telemetry_buffer_manager_example.cpp
@@ -39,7 +39,20 @@ using namespace yarp::telemetry;
     else
         std::cout << "Something went wrong..." << std::endl;
 
+    yarp::telemetry::BufferManager<vector<double>> bm_v({ {"one",{4,1}},
+                                                        {"two",{4,1}} }, 3);
 
+    for (int i = 0; i < 10; i++) {
+        bm_v.push_back({ i+1.0, i+2.0, i+3.0, i+4.0  }, "one");
+        yarp::os::Time::delay(0.2);
+        bm_v.push_back({ (double)i, i*2.0, i*3.0, i*4.0 }, "two");
+    }
+
+    // ISSUES HERE
+    //if (bm_v.saveToFile("buffer_manager_test_vector.mat"))
+    //    std::cout << "File saved correctly!" << std::endl;
+    //else
+    //    std::cout << "Something went wrong..." << std::endl;
 
     return 0;
  }

--- a/src/examples/telemetry_buffer_manager_example.cpp
+++ b/src/examples/telemetry_buffer_manager_example.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+
+#include <yarp/os/Time.h>
+#include <yarp/os/Network.h>
+#include <yarp/telemetry/BufferManager.h>
+
+#include <iostream>
+#include <iomanip>
+#include <chrono>
+#include <thread>
+#include <vector>
+
+using namespace std;
+using namespace yarp::os;
+using namespace yarp::telemetry;
+
+ int main()
+ {
+    Network yarp;
+
+    yarp::telemetry::BufferManager<int32_t> bm({ {"one",{1,1}},
+                                                 {"two",{1,1}} }, 3);
+
+    for (int i = 0; i < 10; i++) {
+        bm.push_back(i, "one");
+        yarp::os::Time::delay(0.2);
+        bm.push_back(i + 1, "two");
+    }
+
+    if (bm.saveToFile("buffer_manager_test.mat"))
+        std::cout << "File saved correctly!" << std::endl;
+    else
+        std::cout << "Something went wrong..." << std::endl;
+
+
+
+    return 0;
+ }

--- a/src/examples/telemetry_buffer_manager_example.cpp
+++ b/src/examples/telemetry_buffer_manager_example.cpp
@@ -29,9 +29,9 @@ using namespace yarp::telemetry;
                                                  {"two",{1,1}} }, 3);
 
     for (int i = 0; i < 10; i++) {
-        bm.push_back(i, "one");
+        bm.push_back({ i }, "one");
         yarp::os::Time::delay(0.2);
-        bm.push_back(i + 1, "two");
+        bm.push_back({ i + 1 }, "two");
     }
 
     if (bm.saveToFile("buffer_manager_test.mat"))
@@ -39,8 +39,8 @@ using namespace yarp::telemetry;
     else
         std::cout << "Something went wrong..." << std::endl;
 
-    yarp::telemetry::BufferManager<vector<double>> bm_v({ {"one",{4,1}},
-                                                        {"two",{4,1}} }, 3);
+    yarp::telemetry::BufferManager<double> bm_v({ {"one",{4,1}},
+                                                  {"two",{4,1}} }, 3);
 
     for (int i = 0; i < 10; i++) {
         bm_v.push_back({ i+1.0, i+2.0, i+3.0, i+4.0  }, "one");
@@ -49,10 +49,10 @@ using namespace yarp::telemetry;
     }
 
     // ISSUES HERE
-    //if (bm_v.saveToFile("buffer_manager_test_vector.mat"))
-    //    std::cout << "File saved correctly!" << std::endl;
-    //else
-    //    std::cout << "Something went wrong..." << std::endl;
+    if (bm_v.saveToFile("buffer_manager_test_vector.mat"))
+        std::cout << "File saved correctly!" << std::endl;
+    else
+        std::cout << "Something went wrong..." << std::endl;
 
     return 0;
  }

--- a/src/libYARP_telemetry/src/CMakeLists.txt
+++ b/src/libYARP_telemetry/src/CMakeLists.txt
@@ -12,6 +12,7 @@ set(YARP_telemetry_HDRS
   yarp/telemetry/Test.h
   yarp/telemetry/Record.h
   yarp/telemetry/Buffer.h
+  yarp/telemetry/BufferManager.h
 )
 set(YARP_telemetry_SRCS
   yarp/telemetry/Test.cpp
@@ -52,7 +53,7 @@ target_compile_features(YARP_telemetry PUBLIC cxx_std_17)
 target_link_libraries(YARP_telemetry PUBLIC YARP::YARP_conf
                                             YARP::YARP_os
                                             Boost::boost
-                                     PRIVATE matioCpp::matioCpp)
+                                     matioCpp::matioCpp) # This has to become PRIVATE
 list(APPEND YARP_telemetry_PUBLIC_DEPS YARP_conf)
 
 set_property(TARGET YARP_telemetry PROPERTY PUBLIC_HEADER ${YARP_telemetry_HDRS})

--- a/src/libYARP_telemetry/src/CMakeLists.txt
+++ b/src/libYARP_telemetry/src/CMakeLists.txt
@@ -53,7 +53,7 @@ target_compile_features(YARP_telemetry PUBLIC cxx_std_17)
 target_link_libraries(YARP_telemetry PUBLIC YARP::YARP_conf
                                             YARP::YARP_os
                                             Boost::boost
-                                     matioCpp::matioCpp) # This has to become PRIVATE
+                                            matioCpp::matioCpp)
 list(APPEND YARP_telemetry_PUBLIC_DEPS YARP_conf)
 
 set_property(TARGET YARP_telemetry PROPERTY PUBLIC_HEADER ${YARP_telemetry_HDRS})

--- a/src/libYARP_telemetry/src/yarp/telemetry/Buffer.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/Buffer.h
@@ -17,6 +17,7 @@
 
 namespace yarp::telemetry {
 
+
 template<class T>
 class Buffer {
 public:
@@ -36,14 +37,8 @@ public:
 
     virtual ~Buffer() = default;
 
-    Buffer(size_t num_elements,  const std::vector<size_t>& dimensions,
-        const std::string& name): m_buffer_ptr(std::make_shared<boost::circular_buffer<Record<T>>>(num_elements)),
-                                  m_dimensions(dimensions), m_variable_name(name) {
-
-    }
-
-    Buffer(size_t num_elements, const std::string& name): m_buffer_ptr(std::make_shared<boost::circular_buffer<Record<T>>>(num_elements)),
-                                                          m_variable_name(name) {
+    explicit Buffer(size_t num_elements): m_buffer_ptr(std::make_shared<boost::circular_buffer<Record<T>>>(num_elements))
+    {
 
     }
 
@@ -89,27 +84,22 @@ public:
         return m_buffer_ptr->begin();
     }
 
-    const_iterator end() const noexcept {
-        return m_buffer_ptr->end();
+    void clear() noexcept {
+        return m_buffer_ptr->clear();
+    
     }
 
-    // TODO maybe this class has to be a struct??
-    std::vector<size_t> getDimensions() const {
-        return m_dimensions;
+    const_iterator end() const noexcept {
+        return m_buffer_ptr->end();
     }
 
     std::shared_ptr<boost::circular_buffer<Record<T>>> getBufferSharedPtr() const {
         return m_buffer_ptr;
     }
 
-    std::string getVariableName() const {
-        return m_variable_name;
-    }
-
 private:
     std::shared_ptr<boost::circular_buffer<Record<T>>> m_buffer_ptr;
-    std::vector<size_t> m_dimensions{1,1};
-    std::string m_variable_name;
+
 
 };
 

--- a/src/libYARP_telemetry/src/yarp/telemetry/BufferManager.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/BufferManager.h
@@ -13,6 +13,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <iostream>
 #include <assert.h>
 #include <yarp/os/Time.h>
 #include <matioCpp/matioCpp.h>
@@ -62,28 +63,26 @@ public:
         if (filename.empty())
             return false;
         // now we initialize the proto-timeseries structure
-        vector<matioCpp::Variable> signalsVect;
+        std::vector<matioCpp::Variable> signalsVect;
         // and the matioCpp struct for these signals
         for (auto& [var_name, buff] : m_buffer_map) {
             if (!buff.full())
             {
-                cout << "not enough data points collected for " << var_name << endl;
+                std::cout << "not enough data points collected for " << var_name << std::endl;
                 continue;
             }
-            // TODO put mutexes here....
-            std::vector<Record<T > > _collection_copy(buff.begin(), buff.end());
-            buff.clear();
-            vector<T> linear_matrix;
-            vector<double> timestamp_vector;
+
+            std::vector<T> linear_matrix;
+            std::vector<double> timestamp_vector;
 
             // the number of timesteps is the size of our collection
-            int num_timesteps = _collection_copy.size();
+            int num_timesteps = buff.size();
 
 
             // TODO HOW TO HANDLE vectors ?? Probably with specialization of functions
             // we first collapse the matrix of data into a single vector, in preparation for matioCpp convertion
-
-            for (auto& _cell : _collection_copy)
+            // TODO put mutexes here....
+            for (auto& _cell : buff)
             {
                 for (auto& _el : _cell.m_datum)
                 {
@@ -91,6 +90,7 @@ public:
                 }
                 timestamp_vector.push_back(_cell.m_ts);
             }
+            buff.clear();
 
             // now we start the matioCpp convertion process
 
@@ -99,7 +99,7 @@ public:
             timestamps = timestamp_vector;
 
             // and the structures for the actual data too
-            vector<matioCpp::Variable> test_data;
+            std::vector<matioCpp::Variable> test_data;
 
             // now we create the vector for the dimensions
 

--- a/src/libYARP_telemetry/src/yarp/telemetry/BufferManager.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/BufferManager.h
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_TELEMETRY_BUFFER_MANAGER_H
+#define YARP_TELEMETRY_BUFFER_MANAGER_H
+
+#include <yarp/telemetry/Buffer.h>
+#include <map>
+#include <string>
+#include <vector>
+#include <assert.h>
+#include <yarp/os/Time.h>
+#include <matioCpp/matioCpp.h>
+
+namespace yarp::telemetry {
+
+using dimensions_t = std::vector<size_t>;
+
+struct BufferInfo {
+    std::string m_var_name;
+    dimensions_t m_dimensions{ 1,1 };
+};
+template<class T>
+class BufferManager {
+public:
+    BufferManager() = delete;
+    BufferManager(const std::vector<BufferInfo>& listOfVars, size_t n_samples) {
+		assert(listOfVars.size() != 0);
+		for (const auto& s : listOfVars) {
+			m_buffer_map.insert(std::pair<std::string, yarp::telemetry::Buffer<T>>(s.m_var_name,Buffer<T>(n_samples)));
+            m_dimensions_map.insert(std::pair<std::string, yarp::telemetry::dimensions_t>(s.m_var_name, s.m_dimensions));
+		}
+	}
+
+    // TODO: check if I am pushing a vector with the right dimensions
+    inline void push_back(const T& elem, const std::string& var_name)
+    {
+        m_buffer_map.at(var_name).push_back(Record<T>(yarp::os::Time::now(), elem));
+    }
+
+
+    // TODO: check if I am pushing a vector with the right dimensions
+    inline void push_back(T&& elem, const std::string& var_name)
+    {
+        m_buffer_map.at(var_name).push_back(Record<T>(yarp::os::Time::now(), std::move(elem)));
+    }
+
+    bool saveToFile(const std::string& filename) {
+        if (filename.empty())
+            return false;
+        // now we initialize the proto-timeseries structure
+        vector<matioCpp::Variable> signalsVect;
+        // and the matioCpp struct for these signals
+        for (auto& [var_name, buff] : m_buffer_map) {
+            if (!buff.full())
+            {
+                cout << "not enough data points collected for " << var_name << endl;
+                continue;
+            }
+            // TODO put mutexes here....
+            std::vector<Record<T > > _collection_copy(buff.begin(), buff.end());
+            buff.clear();
+            vector<T> linear_matrix;
+            vector<double> timestamp_vector;
+
+            // the number of timesteps is the size of our collection
+            int num_timesteps = _collection_copy.size();
+
+
+            // TODO HOW TO HANDLE vectors ?? Probably with specialization of functions
+            // we first collapse the matrix of data into a single vector, in preparation for matioCpp convertion
+
+            for (auto& _cell : _collection_copy)
+            {
+                linear_matrix.push_back(_cell.m_datum);
+                timestamp_vector.push_back(_cell.m_ts);
+            }
+
+            // now we start the matioCpp convertion process
+
+            // first create timestamps vector
+            matioCpp::Vector<double> timestamps("timestamps");
+            timestamps = timestamp_vector;
+
+            // and the structures for the actual data too
+            vector<matioCpp::Variable> test_data;
+
+            // now we create the vector for the dimensions
+
+            std::vector<int> dimensions_data_vect {num_timesteps, (int)m_dimensions_map.at(var_name)[0] , (int)m_dimensions_map.at(var_name)[1] };
+            matioCpp::Vector<int> dimensions_data("dimensions");
+            dimensions_data = dimensions_data_vect;
+
+            // now we populate the matioCpp matrix
+            matioCpp::MultiDimensionalArray<T> out("data", {m_dimensions_map.at(var_name)[0] , m_dimensions_map.at(var_name)[1], (size_t)num_timesteps }, linear_matrix.data());
+            test_data.emplace_back(out); // Data
+
+            test_data.emplace_back(dimensions_data); // dimensions vector
+
+            test_data.emplace_back(matioCpp::String("name", var_name)); // name of the signal
+            test_data.emplace_back(timestamps);
+
+            // we store it as a matioCpp struct
+            matioCpp::Struct data_struct(var_name, test_data);
+
+            // now we create the vector that stores different signals (in case we had more than one)
+            signalsVect.emplace_back(data_struct);
+
+
+        }
+
+        matioCpp::Struct timeSeries("Output", signalsVect);
+        // and finally we write the file
+        matioCpp::File file = matioCpp::File::Create(filename);
+        return file.write(timeSeries);
+    }
+private:
+	std::map<std::string, Buffer<T>> m_buffer_map;
+    std::map<std::string, dimensions_t> m_dimensions_map;
+
+};
+
+} // yarp::telemetry
+
+#endif

--- a/src/libYARP_telemetry/src/yarp/telemetry/BufferManager.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/BufferManager.h
@@ -42,16 +42,13 @@ public:
 		}
 	}
 
-    // TODO: check if I am pushing a vector with the right dimensions
     inline void push_back(const std::vector<T>& elem, const std::string& var_name)
     {
-
         assert(elem.size() == m_dimensions_map.at(var_name)[0] * m_dimensions_map.at(var_name)[1]);
         m_buffer_map.at(var_name).push_back(Record<T>(yarp::os::Time::now(), elem));
     }
 
 
-    // TODO: check if I am pushing a vector with the right dimensions
     inline void push_back(std::vector<T>&& elem, const std::string& var_name)
     {
         assert(elem.size() == m_dimensions_map.at(var_name)[0] * m_dimensions_map.at(var_name)[1]);
@@ -79,7 +76,6 @@ public:
             int num_timesteps = buff.size();
 
 
-            // TODO HOW TO HANDLE vectors ?? Probably with specialization of functions
             // we first collapse the matrix of data into a single vector, in preparation for matioCpp convertion
             // TODO put mutexes here....
             for (auto& _cell : buff)

--- a/src/libYARP_telemetry/src/yarp/telemetry/Record.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/Record.h
@@ -16,16 +16,16 @@ namespace yarp::telemetry {
 template<class T>
 struct Record
 {
-    yarp::os::Stamp m_ts;
+    double m_ts;
     T m_datum;
 
 
-    Record(const yarp::os::Stamp& _ts,
+    Record(const double& _ts,
            const T& _datum) : m_ts(_ts), m_datum(_datum) {
                m_payload = sizeof(m_ts) + sizeof(m_datum);
     }
 
-    Record(const yarp::os::Stamp& _ts,
+    Record(const double& _ts,
            T&& _datum) : m_ts(_ts), m_datum(std::move(_datum)) {
                m_payload = sizeof(m_ts) + sizeof(m_datum);
     }

--- a/src/libYARP_telemetry/src/yarp/telemetry/Record.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/Record.h
@@ -10,6 +10,7 @@
 #define YARP_TELEMETRY_RECORD_H
 
 #include <yarp/os/Stamp.h>
+#include <vector>
 
 namespace yarp::telemetry {
 
@@ -17,25 +18,25 @@ template<class T>
 struct Record
 {
     double m_ts;
-    T m_datum;
+    std::vector<T> m_datum;
 
 
     Record(const double& _ts,
-           const T& _datum) : m_ts(_ts), m_datum(_datum) {
-               m_payload = sizeof(m_ts) + sizeof(m_datum);
+           const std::vector<T>& _datum) : m_ts(_ts), m_datum(_datum) {
+               m_payload = sizeof(m_ts) + sizeof(m_datum) + sizeof(T) * m_datum.capacity();
     }
 
     Record(const double& _ts,
-           T&& _datum) : m_ts(_ts), m_datum(std::move(_datum)) {
-               m_payload = sizeof(m_ts) + sizeof(m_datum);
+           std::vector<T>&& _datum) : m_ts(_ts), m_datum(std::move(_datum)) {
+               m_payload = sizeof(m_ts) + sizeof(m_datum) + sizeof(T) * m_datum.capacity();
     }
 
-    uint32_t getPayload() const {
+    size_t getPayload() const {
         return m_payload;
     }
 
     private:
-    uint32_t m_payload{0};
+    size_t m_payload{0};
 
     // Trying to apply the rule of zero
 


### PR DESCRIPTION
It fixes #29 
It fixes #23
 
This PR introduces these changes:

- Use `double` as timestamp in `Record<T>` (see https://github.com/robotology-playground/yarp-telemetry/issues/28#issuecomment-758003434)
- Use `std::vector<T>` as type for `m_datum` of `Record<T>`(see https://github.com/robotology-playground/yarp-telemetry/issues/23#issuecomment-756782927).
- Implements https://github.com/robotology-playground/yarp-telemetry/pull/27#issuecomment-758001061
- Add `BufferManager` class

This is a template class that contains a `std::map<string, telemetry::Buffer<T>>` that contains all the user-defined `Buffer`s, each one associated to a variable.
Each `BufferManager` defines a .mat structure containing all the variables.

For now it DOES NOT handle the multithreading.

Here is the example of scalar signals:

```c++
yarp::telemetry::BufferManager<int32_t> bm({ {"one",{1,1}},
                                                 {"two",{1,1}} }, 3);

for (int i = 0; i < 10; i++) {
    bm.push_back({ i }, "one");
    yarp::os::Time::delay(0.2);
    bm.push_back({ i + 1 }, "two");
}
```

That produces:

```
buffer_manager_test = 

  struct with fields:

    one: [1×1 struct]
    two: [1×1 struct]


buffer_manager_test.one

ans = 

  struct with fields:

          data: [1×1×3 int32]
    dimensions: [3 1 1]
          name: 'one'
    timestamps: [523132.9969457 523133.1979436 523133.3988861]
```
Here is the example of vector signals

```c++
yarp::telemetry::BufferManager<double> bm_v({ {"one",{4,1}},
                                              {"two",{4,1}} }, 3);

for (int i = 0; i < 10; i++) {
    bm_v.push_back({ i+1.0, i+2.0, i+3.0, i+4.0  }, "one");
    yarp::os::Time::delay(0.2);
    bm_v.push_back({ (double)i, i*2.0, i*3.0, i*4.0 }, "two");
}



```
That produces

```
buffer_manager_test_vector = 

  struct with fields:

    one: [1×1 struct]
    two: [1×1 struct]

>> buffer_manager_test_vector.one

ans = 

  struct with fields:

          data: [4×1×3 double]
    dimensions: [3 4 1]
          name: 'one'
    timestamps: [523135.0186688 523135.219639 523135.4203739]
```

Please review code.

cc @S-Dafarra 