### PR TITLE
BufferManager: add auto save option

### DIFF
--- a/src/examples/telemetry_buffer_manager_example.cpp
+++ b/src/examples/telemetry_buffer_manager_example.cpp
@@ -25,7 +25,8 @@ using namespace yarp::telemetry;
  {
     Network yarp;
 
-    yarp::telemetry::BufferManager<int32_t> bm({ {"one",{1,1}},
+    yarp::telemetry::BufferManager<int32_t> bm("buffer_manager_test.mat",
+                                               { {"one",{1,1}},
                                                  {"two",{1,1}} }, 3);
 
     for (int i = 0; i < 10; i++) {
@@ -34,24 +35,20 @@ using namespace yarp::telemetry;
         bm.push_back({ i + 1 }, "two");
     }
 
-    if (bm.saveToFile("buffer_manager_test.mat"))
+    if (bm.saveToFile())
         std::cout << "File saved correctly!" << std::endl;
     else
         std::cout << "Something went wrong..." << std::endl;
 
-    yarp::telemetry::BufferManager<double> bm_v({ {"one",{4,1}},
-                                                  {"two",{4,1}} }, 3);
+    yarp::telemetry::BufferManager<double> bm_v("buffer_manager_test_vector.mat",
+                                               { {"one",{4,1}},
+                                                 {"two",{4,1}} }, 3, true);
 
     for (int i = 0; i < 10; i++) {
         bm_v.push_back({ i+1.0, i+2.0, i+3.0, i+4.0  }, "one");
         yarp::os::Time::delay(0.2);
         bm_v.push_back({ (double)i, i*2.0, i*3.0, i*4.0 }, "two");
     }
-
-    if (bm_v.saveToFile("buffer_manager_test_vector.mat"))
-        std::cout << "File saved correctly!" << std::endl;
-    else
-        std::cout << "Something went wrong..." << std::endl;
 
     return 0;
  }

--- a/src/libYARP_telemetry/src/yarp/telemetry/BufferManager.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/BufferManager.h
@@ -36,10 +36,10 @@ public:
     BufferManager() = delete;
     BufferManager(const std::string& filename, const std::vector<BufferInfo>& listOfVars,
                   size_t n_samples, bool auto_save=false) : m_filename(filename), m_auto_save(auto_save) {
-	    assert(listOfVars.size() != 0);
+        assert(listOfVars.size() != 0);
         assert(!filename.empty());
-		for (const auto& s : listOfVars) {
-			m_buffer_map.insert(std::pair<std::string, yarp::telemetry::Buffer<T>>(s.m_var_name,Buffer<T>(n_samples)));
+        for (const auto& s : listOfVars) {
+            m_buffer_map.insert(std::pair<std::string, yarp::telemetry::Buffer<T>>(s.m_var_name,Buffer<T>(n_samples)));
             m_dimensions_map.insert(std::pair<std::string, yarp::telemetry::dimensions_t>(s.m_var_name, s.m_dimensions));
 		}
 	}

--- a/src/libYARP_telemetry/src/yarp/telemetry/BufferManager.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/BufferManager.h
@@ -34,13 +34,21 @@ class BufferManager {
 
 public:
     BufferManager() = delete;
-    BufferManager(const std::vector<BufferInfo>& listOfVars, size_t n_samples) {
-		assert(listOfVars.size() != 0);
+    BufferManager(const std::string& filename, const std::vector<BufferInfo>& listOfVars,
+                  size_t n_samples, bool auto_save=false) : m_filename(filename), m_auto_save(auto_save) {
+	    assert(listOfVars.size() != 0);
+        assert(!filename.empty());
 		for (const auto& s : listOfVars) {
 			m_buffer_map.insert(std::pair<std::string, yarp::telemetry::Buffer<T>>(s.m_var_name,Buffer<T>(n_samples)));
             m_dimensions_map.insert(std::pair<std::string, yarp::telemetry::dimensions_t>(s.m_var_name, s.m_dimensions));
 		}
 	}
+
+    ~BufferManager() {
+        if (m_auto_save) {
+            saveToFile();
+        }
+    }
 
     inline void push_back(const std::vector<T>& elem, const std::string& var_name)
     {
@@ -56,9 +64,8 @@ public:
 
     }
 
-    bool saveToFile(const std::string& filename) {
-        if (filename.empty())
-            return false;
+    bool saveToFile() {
+
         // now we initialize the proto-timeseries structure
         std::vector<matioCpp::Variable> signalsVect;
         // and the matioCpp struct for these signals
@@ -120,14 +127,16 @@ public:
 
 
         }
-        auto point_pos = filename.find('.');
-        matioCpp::Struct timeSeries(std::string(filename.begin(), filename.begin()+point_pos), signalsVect);
+        auto point_pos = m_filename.find('.');
+        matioCpp::Struct timeSeries(std::string(m_filename.begin(), m_filename.begin()+point_pos), signalsVect);
         // and finally we write the file
-        matioCpp::File file = matioCpp::File::Create(filename);
+        matioCpp::File file = matioCpp::File::Create(m_filename);
         return file.write(timeSeries);
     }
 private:
-	std::map<std::string, Buffer<T>> m_buffer_map;
+    std::string m_filename;
+    bool m_auto_save;
+    std::map<std::string, Buffer<T>> m_buffer_map;
     std::map<std::string, dimensions_t> m_dimensions_map;
 
 };

--- a/src/libYARP_telemetry/src/yarp/telemetry/Record.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/Record.h
@@ -9,7 +9,6 @@
 #ifndef YARP_TELEMETRY_RECORD_H
 #define YARP_TELEMETRY_RECORD_H
 
-#include <yarp/os/Stamp.h>
 #include <vector>
 
 namespace yarp::telemetry {


### PR DESCRIPTION
As we discussed in the last meeting we decided to implement the auto-save option in order to save the `.mat` file in the destructor.

The option is **false by default** but this can be changed.
Moreover, I also changed the example that uses the `BufferManager` in order to exploit this autosave option.

It fixes #35 

Please review code.