### PR TITLE
Cmake: fix public deps of YARP_telemetry

### DIFF
--- a/src/libYARP_telemetry/src/CMakeLists.txt
+++ b/src/libYARP_telemetry/src/CMakeLists.txt
@@ -54,7 +54,10 @@ target_link_libraries(YARP_telemetry PUBLIC YARP::YARP_conf
                                             YARP::YARP_os
                                             Boost::boost
                                             matioCpp::matioCpp)
-list(APPEND YARP_telemetry_PUBLIC_DEPS YARP_conf)
+list(APPEND YARP_telemetry_PUBLIC_DEPS YARP_conf
+                                       YARP_os
+                                       Boost
+                                       matioCpp)
 
 set_property(TARGET YARP_telemetry PROPERTY PUBLIC_HEADER ${YARP_telemetry_HDRS})
 set_property(TARGET YARP_telemetry PROPERTY PRIVATE_HEADER ${YARP_telemetry_IMPL_HDRS})


### PR DESCRIPTION
Since the `YARP_telemetry_PUBLIC_DEPS` was not correctly set, it was possible to consume this library without linking `matio-cpp` library, triggering a linking issue (#44)

Please review code.