### PR TITLE
BufferManager: fix order dimensions field

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ ans =
   struct with fields:
 
           data: [1×1×3 int32]
-    dimensions: [3 1 1]
+    dimensions: [1 1 3]
           name: 'one'
     timestamps: [523132.9969457 523133.1979436 523133.3988861]
 ```
@@ -99,8 +99,8 @@ ans =
 
 ### Example vector variable
 
-It is possible to save and dump also vector and matrix variables.
-Here is the code snippet for dumping in a `.mat` file 3 samples of the 4x1 vector varibles `"one"` and `"two"`.
+It is possible to save and dump also vector variables.
+Here is the code snippet for dumping in a `.mat` file 3 samples of the 4x1 vector variables `"one"` and `"two"`.
 
 ```c++
 yarp::telemetry::BufferManager<double> bm_v({ {"one",{4,1}},
@@ -133,13 +133,44 @@ ans =
   struct with fields:
 
           data: [4×1×3 double]
-    dimensions: [3 4 1]
+    dimensions: [4 1 3]
           name: 'one'
     timestamps: [523135.0186688 523135.219639 523135.4203739]
 ```
 
+### Example matrix variable
+
+Here is the code snippet for dumping in a `.mat` file 3 samples of the 2x3 matrix variable`"one"` and of the 3x2 matrix variable `"two"`.
+
+```c++
+yarp::telemetry::BufferManager<int32_t> bm_m("buffer_manager_test_matrix.mat",
+                                             { {"one",{2,3}},
+                                             {"two",{3,2}} }, 3, true);
+    
+    for (int i = 0; i < 10; i++) {
+        bm_m.push_back({ i + 1, i + 2, i + 3, i + 4, i + 5, i + 6 }, "one");
+        yarp::os::Time::delay(0.2);
+        bm_m.push_back({ i * 1, i * 2, i * 3, i * 4, i * 5, i * 6 }, "two");
+    }
+
+```
+
+```
+>> buffer_manager_test_matrix.one
+
+ans = 
+
+  struct with fields:
+
+          data: [2×3×3 int32]
+    dimensions: [2 3 3]
+          name: 'one'
+    timestamps: [112104.7605783 112104.9608881 112105.1611651]
+    
+```
 
 ## Contributing
+
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
 
 

--- a/src/examples/telemetry_buffer_manager_example.cpp
+++ b/src/examples/telemetry_buffer_manager_example.cpp
@@ -35,6 +35,16 @@ using namespace yarp::telemetry;
         bm.push_back({ i + 1 }, "two");
     }
 
+    yarp::telemetry::BufferManager<int32_t> bm_m("buffer_manager_test_matrix.mat",
+        { {"one",{2,3}},
+          {"two",{3,2}} }, 3, true);
+
+    for (int i = 0; i < 10; i++) {
+        bm_m.push_back({ i + 1, i + 2, i + 3, i + 4, i + 5, i + 6 }, "one");
+        yarp::os::Time::delay(0.2);
+        bm_m.push_back({ i * 1, i * 2, i * 3, i * 4, i * 5, i * 6 }, "two");
+    }
+
     if (bm.saveToFile())
         std::cout << "File saved correctly!" << std::endl;
     else

--- a/src/libYARP_telemetry/src/yarp/telemetry/BufferManager.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/BufferManager.h
@@ -105,8 +105,8 @@ public:
             std::vector<matioCpp::Variable> test_data;
 
             // now we create the vector for the dimensions
-
-            std::vector<int> dimensions_data_vect {num_timesteps, (int)m_dimensions_map.at(var_name)[0] , (int)m_dimensions_map.at(var_name)[1] };
+            // The first two dimensions are the r and c of the sample, the number of sample has to be the last dimension.
+            std::vector<int> dimensions_data_vect {(int)m_dimensions_map.at(var_name)[0] , (int)m_dimensions_map.at(var_name)[1], num_timesteps};
             matioCpp::Vector<int> dimensions_data("dimensions");
             dimensions_data = dimensions_data_vect;
 


### PR DESCRIPTION
After an analysis on who `matio-cpp` works with @AlexAntn we discovered that the first two dimensions have to represent the single sample, and the one regarding the number of samples is to be the last one in the list.

It fixes #45 

Moreover, we added an example using matrix variables(2x3 and 3x2)

cc @S-Dafarra 
