### PR TITLE
BufferManager: add configuration methods and examples enhancement

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,19 +58,28 @@ target_link_libraries(myApp YARP::YARP_telemetry)
 Here is the code snippet for dumping in a `.mat` file 3 samples of the scalar varibles `"one"` and `"two"`.
 
 ```c++
-yarp::telemetry::BufferManager<int32_t> bm({ {"one",{1,1}},
-                                                 {"two",{1,1}} }, 3);
+    yarp::telemetry::BufferManager<int32_t> bm(n_samples);
+    bm.setFileName("buffer_manager_test.mat");
+    ChannelInfo var_one{ "one", {1,1} };
+    ChannelInfo var_two{ "two", {1,1} };
 
-for (int i = 0; i < 10; i++) {
-    bm.push_back({ i }, "one");
-    yarp::os::Time::delay(0.2);
-    bm.push_back({ i + 1 }, "two");
-}
+    auto ok = bm.addChannel(var_one);
+    ok = ok && bm.addChannel(var_two);
+    if (!ok) {
+        std::cout << "Problem adding variables...."<<std::endl;
+        return 1;
+    }
 
-if (bm.saveToFile("buffer_manager_test.mat"))
-    std::cout << "File saved correctly!" << std::endl;
-else
-    std::cout << "Something went wrong..." << std::endl;
+    for (int i = 0; i < 10; i++) {
+        bm.push_back({ i }, "one");
+        yarp::os::Time::delay(0.2);
+        bm.push_back({ i + 1 }, "two");
+    }
+
+    if (bm.saveToFile())
+        std::cout << "File saved correctly!" << std::endl;
+    else
+        std::cout << "Something went wrong..." << std::endl;
 
 ```
 And here is the resulting .mat file:
@@ -103,19 +112,19 @@ It is possible to save and dump also vector variables.
 Here is the code snippet for dumping in a `.mat` file 3 samples of the 4x1 vector variables `"one"` and `"two"`.
 
 ```c++
-yarp::telemetry::BufferManager<double> bm_v({ {"one",{4,1}},
-                                              {"two",{4,1}} }, 3);
+    yarp::telemetry::BufferManager<double> bm_v({ {"one",{4,1}},
+                                                  {"two",{4,1}} }, 3);
 
-for (int i = 0; i < 10; i++) {
-    bm_v.push_back({ i+1.0, i+2.0, i+3.0, i+4.0  }, "one");
-    yarp::os::Time::delay(0.2);
-    bm_v.push_back({ (double)i, i*2.0, i*3.0, i*4.0 }, "two");
-}
+    for (int i = 0; i < 10; i++) {
+        bm_v.push_back({ i+1.0, i+2.0, i+3.0, i+4.0  }, "one");
+        yarp::os::Time::delay(0.2);
+        bm_v.push_back({ (double)i, i*2.0, i*3.0, i*4.0 }, "two");
+    }
 
-if (bm_v.saveToFile("buffer_manager_test_vector.mat"))
-    std::cout << "File saved correctly!" << std::endl;
-else
-    std::cout << "Something went wrong..." << std::endl;
+    if (bm_v.saveToFile("buffer_manager_test_vector.mat"))
+        std::cout << "File saved correctly!" << std::endl;
+    else
+        std::cout << "Something went wrong..." << std::endl;
 ```
 
 ```
@@ -143,10 +152,17 @@ ans =
 Here is the code snippet for dumping in a `.mat` file 3 samples of the 2x3 matrix variable`"one"` and of the 3x2 matrix variable `"two"`.
 
 ```c++
-yarp::telemetry::BufferManager<int32_t> bm_m("buffer_manager_test_matrix.mat",
-                                             { {"one",{2,3}},
-                                             {"two",{3,2}} }, 3, true);
-    
+    yarp::telemetry::BufferManager<int32_t> bm_m(n_samples, true);
+    bm_m.setFileName("buffer_manager_test_matrix.mat");
+    std::vector<ChannelInfo> vars{ { "one",{2,3} },
+                                   { "two",{3,2} } };
+
+    ok = bm_m.addChannels(vars);
+    if (!ok) {
+        std::cout << "Problem adding variables...."<<std::endl;
+        return 1;
+    }
+
     for (int i = 0; i < 10; i++) {
         bm_m.push_back({ i + 1, i + 2, i + 3, i + 4, i + 5, i + 6 }, "one");
         yarp::os::Time::delay(0.2);

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ Here is the code snippet for dumping in a `.mat` file 3 samples of the scalar va
 ```c++
     yarp::telemetry::BufferManager<int32_t> bm(n_samples);
     bm.setFileName("buffer_manager_test.mat");
-    ChannelInfo var_one{ "one", {1,1} };
-    ChannelInfo var_two{ "two", {1,1} };
+    yarp::telemetry::ChannelInfo var_one{ "one", {1,1} };
+    yarp::telemetry::ChannelInfo var_two{ "two", {1,1} };
 
     auto ok = bm.addChannel(var_one);
     ok = ok && bm.addChannel(var_two);
@@ -154,7 +154,7 @@ Here is the code snippet for dumping in a `.mat` file 3 samples of the 2x3 matri
 ```c++
     yarp::telemetry::BufferManager<int32_t> bm_m(n_samples, true);
     bm_m.setFileName("buffer_manager_test_matrix.mat");
-    std::vector<ChannelInfo> vars{ { "one",{2,3} },
+    std::vector<yarp::telemetry::ChannelInfo> vars{ { "one",{2,3} },
                                    { "two",{3,2} } };
 
     ok = bm_m.addChannels(vars);

--- a/src/examples/telemetry_buffer_manager_example.cpp
+++ b/src/examples/telemetry_buffer_manager_example.cpp
@@ -19,7 +19,6 @@
 
 using namespace std;
 using namespace yarp::os;
-using namespace yarp::telemetry;
 
 constexpr size_t n_samples{3};
 
@@ -30,8 +29,8 @@ int main()
 
     yarp::telemetry::BufferManager<int32_t> bm(n_samples);
     bm.setFileName("buffer_manager_test.mat");
-    ChannelInfo var_one{ "one", {1,1} };
-    ChannelInfo var_two{ "two", {1,1} };
+    yarp::telemetry::ChannelInfo var_one{ "one", {1,1} };
+    yarp::telemetry::ChannelInfo var_two{ "two", {1,1} };
 
     auto ok = bm.addChannel(var_one);
     ok = ok && bm.addChannel(var_two);
@@ -53,7 +52,7 @@ int main()
 
     yarp::telemetry::BufferManager<int32_t> bm_m(n_samples, true);
     bm_m.setFileName("buffer_manager_test_matrix.mat");
-    std::vector<ChannelInfo> vars{ { "one",{2,3} },
+    std::vector<yarp::telemetry::ChannelInfo> vars{ { "one",{2,3} },
                                    { "two",{3,2} } };
 
     ok = bm_m.addChannels(vars);

--- a/src/examples/telemetry_buffer_manager_example.cpp
+++ b/src/examples/telemetry_buffer_manager_example.cpp
@@ -21,13 +21,24 @@ using namespace std;
 using namespace yarp::os;
 using namespace yarp::telemetry;
 
- int main()
- {
+constexpr size_t n_samples{3};
+
+
+int main()
+{
     Network yarp;
 
-    yarp::telemetry::BufferManager<int32_t> bm("buffer_manager_test.mat",
-                                               { {"one",{1,1}},
-                                                 {"two",{1,1}} }, 3);
+    yarp::telemetry::BufferManager<int32_t> bm(n_samples);
+    bm.setFileName("buffer_manager_test.mat");
+    ChannelInfo var_one{ "one", {1,1} };
+    ChannelInfo var_two{ "two", {1,1} };
+
+    auto ok = bm.addChannel(var_one);
+    ok = ok && bm.addChannel(var_two);
+    if (!ok) {
+        std::cout << "Problem adding variables...."<<std::endl;
+        return 1;
+    }
 
     for (int i = 0; i < 10; i++) {
         bm.push_back({ i }, "one");
@@ -35,9 +46,21 @@ using namespace yarp::telemetry;
         bm.push_back({ i + 1 }, "two");
     }
 
-    yarp::telemetry::BufferManager<int32_t> bm_m("buffer_manager_test_matrix.mat",
-        { {"one",{2,3}},
-          {"two",{3,2}} }, 3, true);
+    if (bm.saveToFile())
+        std::cout << "File saved correctly!" << std::endl;
+    else
+        std::cout << "Something went wrong..." << std::endl;
+
+    yarp::telemetry::BufferManager<int32_t> bm_m(n_samples, true);
+    bm_m.setFileName("buffer_manager_test_matrix.mat");
+    std::vector<ChannelInfo> vars{ { "one",{2,3} },
+                                   { "two",{3,2} } };
+
+    ok = bm_m.addChannels(vars);
+    if (!ok) {
+        std::cout << "Problem adding variables...."<<std::endl;
+        return 1;
+    }
 
     for (int i = 0; i < 10; i++) {
         bm_m.push_back({ i + 1, i + 2, i + 3, i + 4, i + 5, i + 6 }, "one");
@@ -45,14 +68,9 @@ using namespace yarp::telemetry;
         bm_m.push_back({ i * 1, i * 2, i * 3, i * 4, i * 5, i * 6 }, "two");
     }
 
-    if (bm.saveToFile())
-        std::cout << "File saved correctly!" << std::endl;
-    else
-        std::cout << "Something went wrong..." << std::endl;
-
     yarp::telemetry::BufferManager<double> bm_v("buffer_manager_test_vector.mat",
                                                { {"one",{4,1}},
-                                                 {"two",{4,1}} }, 3, true);
+                                                 {"two",{4,1}} }, n_samples, true);
 
     for (int i = 0; i < 10; i++) {
         bm_v.push_back({ i+1.0, i+2.0, i+3.0, i+4.0  }, "one");

--- a/src/libYARP_telemetry/src/yarp/telemetry/BufferManager.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/BufferManager.h
@@ -163,8 +163,8 @@ private:
     std::string m_filename;
     bool m_auto_save{false};
     size_t m_n_samples{0};
-    std::map<std::string, Buffer<T>> m_buffer_map;
-    std::map<std::string, dimensions_t> m_dimensions_map;
+    std::unordered_map<std::string, Buffer<T>> m_buffer_map;
+    std::unordered_map<std::string, dimensions_t> m_dimensions_map;
 
 };
 

--- a/src/libYARP_telemetry/src/yarp/telemetry/BufferManager.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/BufferManager.h
@@ -10,7 +10,7 @@
 #define YARP_TELEMETRY_BUFFER_MANAGER_H
 
 #include <yarp/telemetry/Buffer.h>
-#include <map>
+#include <unordered_map>
 #include <string>
 #include <vector>
 #include <iostream>

--- a/src/libYARP_telemetry/src/yarp/telemetry/BufferManager.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/BufferManager.h
@@ -70,9 +70,9 @@ public:
         std::vector<matioCpp::Variable> signalsVect;
         // and the matioCpp struct for these signals
         for (auto& [var_name, buff] : m_buffer_map) {
-            if (!buff.full())
+            if (buff.empty())
             {
-                std::cout << "not enough data points collected for " << var_name << std::endl;
+                std::cout << var_name << " does not contain data, skipping" << std::endl;
                 continue;
             }
 
@@ -126,6 +126,10 @@ public:
             signalsVect.emplace_back(data_struct);
 
 
+        }
+        if (signalsVect.empty()) {
+            std::cout << "No available data to be saved" << std::endl;
+            return false;
         }
         auto point_pos = m_filename.find('.');
         matioCpp::Struct timeSeries(std::string(m_filename.begin(), m_filename.begin()+point_pos), signalsVect);


### PR DESCRIPTION
This PR adds some configuration methods, now you are no more forced to configure the BufferManager at the construction phase.
The examples have been cleaned up and refactored accordingly.

Please review code.


cc @S-Dafarra 