### PR TITLE
BufferManager: added a periodic saving method and updated examples

### DIFF
--- a/src/examples/CB_to_matfile_example.cpp
+++ b/src/examples/CB_to_matfile_example.cpp
@@ -95,7 +95,7 @@ class storeData {
       vector<double> timestamp_vector;
 
       // the number of timesteps is the size of our collection
-      int num_timesteps = _collection_copy.size();
+      auto num_timesteps = _collection_copy.size();
       cout << "num timesteps: " << num_timesteps << endl;
       if(num_timesteps < 1)
       {
@@ -128,7 +128,7 @@ class storeData {
       vector<matioCpp::Variable> test_data;
 
       // now we create the vector for the dimensions
-      vector<int> dimensions_data_vect{num_timesteps, size_datum};
+      vector<int> dimensions_data_vect{(int)num_timesteps, size_datum};
       matioCpp::Vector<int> dimensions_data("dimensions");
       dimensions_data = dimensions_data_vect;
 

--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -11,6 +11,7 @@ set(MATIO_MATRIX_EXAMPLE_SRC matio_matrix_example.cpp)
 set(MATIO_TIMESERIES_EXAMPLE_SRC matio_timeseries_example.cpp)
 set(TELEMETRY_BUFFER_EXAMPLE_SRC telemetry_buffer_example.cpp)
 set(TELEMETRY_BUFFER_MANAGER_EXAMPLE_SRC telemetry_buffer_manager_example.cpp)
+set(TELEMETRY_BUFFER_PERIODIC_SAVE_SRC telemetry_buffer_periodic_save.cpp)
 set(CB_TO_MATIO_EXAMPLE_SRC CB_to_matfile_example.cpp)
 
 
@@ -21,12 +22,14 @@ add_executable(matio_matrix_example ${MATIO_MATRIX_EXAMPLE_SRC})
 add_executable(matio_timeseries_example ${MATIO_TIMESERIES_EXAMPLE_SRC})
 add_executable(telemetry_buffer_example ${TELEMETRY_BUFFER_EXAMPLE_SRC})
 add_executable(telemetry_buffer_manager_example ${TELEMETRY_BUFFER_MANAGER_EXAMPLE_SRC})
+add_executable(telemetry_buffer_periodic_save ${TELEMETRY_BUFFER_PERIODIC_SAVE_SRC})
 add_executable(CB_to_matfile_example ${CB_TO_MATIO_EXAMPLE_SRC})
 
 target_compile_features(circular_buffer_example PUBLIC cxx_std_14)
 target_compile_features(circular_buffer_record_example PUBLIC cxx_std_14)
 target_compile_features(telemetry_buffer_example PUBLIC cxx_std_14)
 target_compile_features(telemetry_buffer_manager_example PUBLIC cxx_std_14)
+target_compile_features(telemetry_buffer_periodic_save PUBLIC cxx_std_14)
 
 
 target_link_libraries(circular_buffer_example Boost::boost)
@@ -40,6 +43,10 @@ target_link_libraries(telemetry_buffer_example YARP::YARP_conf
                                                YARP::YARP_init
                                                YARP::YARP_telemetry)
 target_link_libraries(telemetry_buffer_manager_example YARP::YARP_conf
+                                                       YARP::YARP_os
+                                                       YARP::YARP_init
+                                                       YARP::YARP_telemetry)
+target_link_libraries(telemetry_buffer_periodic_save YARP::YARP_conf
                                                        YARP::YARP_os
                                                        YARP::YARP_init
                                                        YARP::YARP_telemetry)

--- a/src/examples/circular_buffer_record_example.cpp
+++ b/src/examples/circular_buffer_record_example.cpp
@@ -30,7 +30,7 @@ using namespace yarp::telemetry;
     // Create a circular buffer with a capacity for 3 Record<int32_t> structures.
     boost::circular_buffer<yarp::telemetry::Record<int32_t>> cb_i(3);
 
-    auto total_payload = 0;
+    size_t total_payload = 0;
     cout<<"The capacity is: "<<cb_i.capacity()<<" and the size is: "<<cb_i.size()<<std::endl;
     // Insert threee elements into the buffer.
     cb_i.push_back(Record(yarp::os::Time::now(), vector<int32_t>{ 1 }));

--- a/src/libYARP_telemetry/src/CMakeLists.txt
+++ b/src/libYARP_telemetry/src/CMakeLists.txt
@@ -51,7 +51,8 @@ target_include_directories(YARP_telemetry
 target_compile_features(YARP_telemetry PUBLIC cxx_std_17)
 
 target_link_libraries(YARP_telemetry PUBLIC Boost::boost
-                                            matioCpp::matioCpp)
+                                            matioCpp::matioCpp
+                                            ${CMAKE_THREAD_LIBS_INIT})
 list(APPEND YARP_telemetry_PUBLIC_DEPS Boost
                                        matioCpp)
 


### PR DESCRIPTION
This PR introduces a periodic saving method to the BufferManager API. 

It runs in a thread that is activated periodically, checking the buffer to see if the amount of data currently stored crosses a specified threshold. If the threshold is crossed, the data is saved to a file, and the buffer is cleared and ready to accept more data.

This is a first step towards ensuring no data loss since we are now not bound by the size of the buffer. The file names are incremented at each save (so, e.g.: `buffer_test_0.mat`, `buffer_test_1.mat`, etc). 

The saving of the file is triggered if any channel crosses the data amount threshold. This ensures that the same .mat file corresponds to the same time-window, even if the number of entries between the channels doesn't match (e.g.: if the channels have different frequencies). 

One issue we found with the current implementation is the case where the save triggers just before a data push - this can lead to the loss of one entry, with the current buffer clearing. In this example we lost an entry from channel "two":

![Screenshot from 2021-01-29 16-35-01](https://user-images.githubusercontent.com/9463167/106295050-3faadc80-6250-11eb-9931-bcc84fed0539.png)

This could potentially be solved with a different buffer cleaning technique (instead of a full clear), or with the introduction of mutexes. 

Also, given the number of parameters being passed to the constructor, I and @Nicogene  have created a `BufferConfig` structure to encode these parameters, making it easier to initialize the `BufferManager`.

It fixes #47 
It fixes #59 