### PR TITLE
BufferManager: add mutex, configuration from file, empty constructor workflow et al

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,24 @@ find_package(matioCpp REQUIRED)
 find_package(Boost REQUIRED)
 find_package(Threads REQUIRED)
 
+option(YARP_TELEMETRY_USES_SYSTEM_nlohmann_json OFF)
+# 3.9.2 is unreleased, this option is not working until that version is not released
+if(YARP_TELEMETRY_USES_SYSTEM_nlohmann_json)
+  find_package(nlohmann_json 3.9.2 REQUIRED)
+else()
+  include(FetchContent)
+
+  FetchContent_Declare(json
+    GIT_REPOSITORY https://github.com/nlohmann/json.git
+    GIT_TAG develop) # awaiting 3.9.2 release for https://github.com/nlohmann/json/issues/2513
+
+  FetchContent_GetProperties(json)
+  if(NOT json_POPULATED)
+    FetchContent_Populate(json)
+    add_subdirectory(${json_SOURCE_DIR} ${json_BINARY_DIR} EXCLUDE_FROM_ALL)
+  endif()
+endif()
+
 
 feature_summary(WHAT ALL INCLUDE_QUIET_PACKAGES)
 

--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -10,6 +10,7 @@ set(MATIO_VECTOR_EXAMPLE_SRC matio_vector_example.cpp)
 set(MATIO_MATRIX_EXAMPLE_SRC matio_matrix_example.cpp)
 set(MATIO_TIMESERIES_EXAMPLE_SRC matio_timeseries_example.cpp)
 set(TELEMETRY_BUFFER_EXAMPLE_SRC telemetry_buffer_example.cpp)
+set(TELEMETRY_BUFFER_MANAGER_CONF_FILE telemetry_buffer_manager_conf_file.cpp)
 set(TELEMETRY_BUFFER_MANAGER_EXAMPLE_SRC telemetry_buffer_manager_example.cpp)
 set(TELEMETRY_BUFFER_PERIODIC_SAVE_SRC telemetry_buffer_periodic_save.cpp)
 set(CB_TO_MATIO_EXAMPLE_SRC CB_to_matfile_example.cpp)
@@ -21,15 +22,17 @@ add_executable(matio_vector_example ${MATIO_VECTOR_EXAMPLE_SRC})
 add_executable(matio_matrix_example ${MATIO_MATRIX_EXAMPLE_SRC})
 add_executable(matio_timeseries_example ${MATIO_TIMESERIES_EXAMPLE_SRC})
 add_executable(telemetry_buffer_example ${TELEMETRY_BUFFER_EXAMPLE_SRC})
+add_executable(telemetry_buffer_manager_conf_file_example ${TELEMETRY_BUFFER_MANAGER_CONF_FILE})
 add_executable(telemetry_buffer_manager_example ${TELEMETRY_BUFFER_MANAGER_EXAMPLE_SRC})
 add_executable(telemetry_buffer_periodic_save ${TELEMETRY_BUFFER_PERIODIC_SAVE_SRC})
 add_executable(CB_to_matfile_example ${CB_TO_MATIO_EXAMPLE_SRC})
 
-target_compile_features(circular_buffer_example PUBLIC cxx_std_14)
-target_compile_features(circular_buffer_record_example PUBLIC cxx_std_14)
-target_compile_features(telemetry_buffer_example PUBLIC cxx_std_14)
-target_compile_features(telemetry_buffer_manager_example PUBLIC cxx_std_14)
-target_compile_features(telemetry_buffer_periodic_save PUBLIC cxx_std_14)
+target_compile_features(circular_buffer_example PUBLIC cxx_std_17)
+target_compile_features(circular_buffer_record_example PUBLIC cxx_std_17)
+target_compile_features(telemetry_buffer_example PUBLIC cxx_std_17)
+target_compile_features(telemetry_buffer_manager_conf_file_example PUBLIC cxx_std_17)
+target_compile_features(telemetry_buffer_manager_example PUBLIC cxx_std_17)
+target_compile_features(telemetry_buffer_periodic_save PUBLIC cxx_std_17)
 
 
 target_link_libraries(circular_buffer_example Boost::boost)
@@ -42,6 +45,10 @@ target_link_libraries(telemetry_buffer_example YARP::YARP_conf
                                                YARP::YARP_os
                                                YARP::YARP_init
                                                YARP::YARP_telemetry)
+target_link_libraries(telemetry_buffer_manager_conf_file_example YARP::YARP_conf
+                                                                 YARP::YARP_os
+                                                                 YARP::YARP_init
+                                                                 YARP::YARP_telemetry)
 target_link_libraries(telemetry_buffer_manager_example YARP::YARP_conf
                                                        YARP::YARP_os
                                                        YARP::YARP_init
@@ -59,3 +66,6 @@ target_link_libraries(CB_to_matfile_example PRIVATE matioCpp::matioCpp
                                                 YARP::YARP_conf
                                                 YARP::YARP_os
                                                 YARP::YARP_init ${CMAKE_THREAD_LIBS_INIT})
+
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/conf/test_json.json
+        DESTINATION ${CMAKE_BINARY_DIR}/bin)

--- a/src/examples/conf/test_json.json
+++ b/src/examples/conf/test_json.json
@@ -1,0 +1,12 @@
+{
+    "filename": "buffer_manager_test_conf_file",
+    "n_samples": 20,
+    "save_period": 1.0,
+    "data_threshold": 10,
+    "auto_save": true,
+    "save_periodically": true,
+    "channels": [
+        ["one",[1,1]],
+        ["two",[1,1]]
+    ]
+  }

--- a/src/examples/telemetry_buffer_manager_conf_file.cpp
+++ b/src/examples/telemetry_buffer_manager_conf_file.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2006-2020 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+
+#include <yarp/os/Time.h>
+#include <yarp/os/Network.h>
+#include <yarp/telemetry/BufferManager.h>
+
+#include <iostream>
+#include <iomanip>
+#include <chrono>
+#include <thread>
+#include <vector>
+
+using namespace std;
+using namespace yarp::os;
+
+constexpr size_t n_samples{20};
+constexpr size_t threshold{10};
+constexpr double check_period{1.0};
+
+
+
+int main()
+{
+    Network yarp;
+    yarp::telemetry::BufferConfig bufferConfig;
+
+    // we configure our API to use our periodic saving option 
+    bufferConfig.n_samples = n_samples;
+    bufferConfig.save_period = check_period;
+    bufferConfig.data_threshold = threshold;
+    bufferConfig.save_periodically = true;
+    std::vector<yarp::telemetry::ChannelInfo> vars{ { "one",{2,3} },
+                                                    { "two",{3,2} } };
+    bufferConfig.channels = vars;
+
+    nlohmann::json j = bufferConfig;
+
+    std::cout << "Here is the resulting json file "<<std::endl;
+    std::cout << j << std::endl;
+
+    yarp::telemetry::BufferManager<int32_t> bm;
+
+    auto ok = bm.configureFromFile("test_json.json");
+
+    if (!ok) {
+        std::cout << "Problems configuring from file" << std::endl;
+        return 1;
+    }
+
+    std::cout << "Starting loop" << std::endl;
+    for (int i = 0; i < 40; i++) {
+        bm.push_back({ i }, "one");
+        yarp::os::Time::delay(0.01);
+        bm.push_back({ i + 1 }, "two");
+    }
+
+    yarp::os::Time::delay(3.0);
+    return 0;
+ }

--- a/src/examples/telemetry_buffer_manager_conf_file.cpp
+++ b/src/examples/telemetry_buffer_manager_conf_file.cpp
@@ -40,14 +40,18 @@ int main()
                                                     { "two",{3,2} } };
     bufferConfig.channels = vars;
 
-    nlohmann::json j = bufferConfig;
+    auto ok = bufferConfigToJson(bufferConfig, "test_json_write.json");
 
-    std::cout << "Here is the resulting json file "<<std::endl;
-    std::cout << j << std::endl;
+    if (!ok) {
+        std::cout << "Problems saving configuration to json" << std::endl;
+        return 1;
+    }
 
     yarp::telemetry::BufferManager<int32_t> bm;
 
-    auto ok = bm.configureFromFile("test_json.json");
+    ok = bufferConfigFromJson(bufferConfig,"test_json.json");
+
+    ok = ok && bm.configure(bufferConfig);
 
     if (!ok) {
         std::cout << "Problems configuring from file" << std::endl;

--- a/src/examples/telemetry_buffer_manager_example.cpp
+++ b/src/examples/telemetry_buffer_manager_example.cpp
@@ -62,7 +62,7 @@ int main()
         std::cout << "Something went wrong..." << std::endl;
 
     // now we test our API with the auto_save option enabled.
-    bufferConfig.m_auto_save = true;
+    bufferConfig.auto_save = true;
 
     yarp::telemetry::BufferManager<int32_t> bm_m(bufferConfig);
     bm_m.setFileName("buffer_manager_test_matrix");
@@ -72,7 +72,7 @@ int main()
         return 1;
     }
     std::vector<yarp::telemetry::ChannelInfo> vars{ { "one",{2,3} },
-                                   { "two",{3,2} } };
+                                                    { "two",{3,2} } };
 
     ok = bm_m.addChannels(vars);
     if (!ok) {
@@ -86,9 +86,11 @@ int main()
         bm_m.push_back({ i * 1, i * 2, i * 3, i * 4, i * 5, i * 6 }, "two");
     }
 
-    yarp::telemetry::BufferManager<double> bm_v("buffer_manager_test_vector",
-                                               { {"one",{4,1}},
-                                                 {"two",{4,1}} }, bufferConfig);
+
+    bufferConfig.channels = { {"one",{4,1}}, {"two",{4,1}} };
+    bufferConfig.filename = "buffer_manager_test_vector";
+
+    yarp::telemetry::BufferManager<double> bm_v(bufferConfig);
     ok = bm_v.setNowFunction(now);
     if (!ok) {
         std::cout << "Problem setting the clock...."<<std::endl;

--- a/src/examples/telemetry_buffer_periodic_save.cpp
+++ b/src/examples/telemetry_buffer_periodic_save.cpp
@@ -22,7 +22,7 @@ using namespace yarp::os;
 
 constexpr size_t n_samples{20};
 constexpr size_t threshold{10};
-constexpr double check_period{100.0};
+constexpr double check_period{1.0};
 
 
 
@@ -34,8 +34,8 @@ int main()
 
     // we configure our API to use our periodic saving option 
     bufferConfig.n_samples = n_samples;
-    bufferConfig.check_period = check_period;
-    bufferConfig.threshold = threshold;
+    bufferConfig.save_period = check_period;
+    bufferConfig.data_threshold = threshold;
     bufferConfig.save_periodically = true;
 
     yarp::telemetry::BufferManager<int32_t> bm(bufferConfig);
@@ -52,17 +52,17 @@ int main()
         std::cout << "Problem adding variables...."<<std::endl;
         return 1;
     }
-
+    std::cout << "Starting loop" << std::endl;
     for (int i = 0; i < 40; i++) {
         bm.push_back({ i }, "one");
-        yarp::os::Time::delay(0.2);
+        yarp::os::Time::delay(0.01);
         bm.push_back({ i + 1 }, "two");
     }
 
-    std::cout << "Second example: " << std::endl;
-
     // now we use also the auto_saving option
-    bufferConfig.m_auto_save = true;
+    bufferConfig.auto_save = true;
+
+    std::cout << "Second example: " << std::endl;
 
     yarp::telemetry::BufferManager<int32_t> bm_m(bufferConfig);
     bm_m.setFileName("buffer_manager_test_matrix");
@@ -77,19 +77,20 @@ int main()
 
     for (int i = 0; i < 40; i++) {
         bm_m.push_back({ i + 1, i + 2, i + 3, i + 4, i + 5, i + 6 }, "one");
-        yarp::os::Time::delay(0.2);
+        yarp::os::Time::delay(0.01);
         bm_m.push_back({ i * 1, i * 2, i * 3, i * 4, i * 5, i * 6 }, "two");
     }
 
     std::cout << "Third example: " << std::endl;
 
-    yarp::telemetry::BufferManager<double> bm_v("buffer_manager_test_vector",
-                                               { {"one",{4,1}},
-                                                 {"two",{4,1}} }, bufferConfig);
-    // bm_v.periodicSave();
+    bufferConfig.channels = { {"one",{4,1}}, {"two",{4,1}} };
+    bufferConfig.filename = "buffer_manager_test_vector";
+
+    yarp::telemetry::BufferManager<double> bm_v(bufferConfig);
+
     for (int i = 0; i < 40; i++) {
         bm_v.push_back({ i+1.0, i+2.0, i+3.0, i+4.0  }, "one");
-        yarp::os::Time::delay(0.2);
+        yarp::os::Time::delay(0.01);
         bm_v.push_back({ (double)i, i*2.0, i*3.0, i*4.0 }, "two");
     }
 

--- a/src/libYARP_telemetry/src/CMakeLists.txt
+++ b/src/libYARP_telemetry/src/CMakeLists.txt
@@ -52,9 +52,11 @@ target_compile_features(YARP_telemetry PUBLIC cxx_std_17)
 
 target_link_libraries(YARP_telemetry PUBLIC Boost::boost
                                             matioCpp::matioCpp
-                                            ${CMAKE_THREAD_LIBS_INIT})
+                                            ${CMAKE_THREAD_LIBS_INIT}
+                                            nlohmann_json::nlohmann_json)
 list(APPEND YARP_telemetry_PUBLIC_DEPS Boost
-                                       matioCpp)
+                                       matioCpp
+                                       nlohmann_json)
 
 set_property(TARGET YARP_telemetry PROPERTY PUBLIC_HEADER ${YARP_telemetry_HDRS})
 set_property(TARGET YARP_telemetry PROPERTY PRIVATE_HEADER ${YARP_telemetry_IMPL_HDRS})

--- a/src/libYARP_telemetry/src/CMakeLists.txt
+++ b/src/libYARP_telemetry/src/CMakeLists.txt
@@ -12,10 +12,12 @@ set(YARP_telemetry_HDRS
   yarp/telemetry/Test.h
   yarp/telemetry/Record.h
   yarp/telemetry/Buffer.h
+  yarp/telemetry/BufferConfig.h
   yarp/telemetry/BufferManager.h
 )
 set(YARP_telemetry_SRCS
   yarp/telemetry/Test.cpp
+  yarp/telemetry/BufferConfig.cpp
 )
 set(YARP_telemetry_IMPL_HDRS )
 set(YARP_telemetry_IMPL_SRCS )
@@ -50,13 +52,13 @@ target_include_directories(YARP_telemetry
 )
 target_compile_features(YARP_telemetry PUBLIC cxx_std_17)
 
-target_link_libraries(YARP_telemetry PUBLIC Boost::boost
-                                            matioCpp::matioCpp
-                                            ${CMAKE_THREAD_LIBS_INIT}
-                                            nlohmann_json::nlohmann_json)
+target_link_libraries(YARP_telemetry PUBLIC  Boost::boost
+                                             matioCpp::matioCpp
+                                             ${CMAKE_THREAD_LIBS_INIT}
+                                     PRIVATE nlohmann_json::nlohmann_json)
 list(APPEND YARP_telemetry_PUBLIC_DEPS Boost
-                                       matioCpp
-                                       nlohmann_json)
+                                       matioCpp)
+list(APPEND YARP_telemetry_PRIVATE_DEPS nlohmann_json)
 
 set_property(TARGET YARP_telemetry PROPERTY PUBLIC_HEADER ${YARP_telemetry_HDRS})
 set_property(TARGET YARP_telemetry PROPERTY PRIVATE_HEADER ${YARP_telemetry_IMPL_HDRS})

--- a/src/libYARP_telemetry/src/yarp/telemetry/Buffer.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/Buffer.h
@@ -68,6 +68,10 @@ public:
         return m_buffer_ptr->empty();
     }
 
+    void resize(size_t new_size) {
+        return m_buffer_ptr->resize(new_size);
+    }
+
     bool full() const {
         return m_buffer_ptr->full();
     }

--- a/src/libYARP_telemetry/src/yarp/telemetry/BufferConfig.cpp
+++ b/src/libYARP_telemetry/src/yarp/telemetry/BufferConfig.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include <nlohmann/json.hpp>
+#include <yarp/telemetry/BufferConfig.h>
+#include <fstream>
+#include <iostream>
+
+namespace yarp::telemetry {
+    // This expects that the name of the json keyword is the same of the relative variable
+    NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(BufferConfig, filename, n_samples, save_period, data_threshold, auto_save, save_periodically, channels)
+}
+bool bufferConfigFromJson(yarp::telemetry::BufferConfig& bufferConfig, const std::string& config_filename) {
+    // read a JSON file
+    std::ifstream input_stream(config_filename);
+    if (!input_stream.is_open()) {
+        std::cout << "Failed to open " << config_filename << std::endl;
+        return false;
+    }
+    nlohmann::json jason_file;
+    input_stream >> jason_file;
+    bufferConfig = jason_file.get<yarp::telemetry::BufferConfig>();
+    input_stream.close();
+    return true;
+}
+
+bool bufferConfigToJson(const yarp::telemetry::BufferConfig& bufferConfig, const std::string& config_filename) {
+    // write to a JSON file
+    std::ofstream out_stream(config_filename);
+    if (!out_stream.is_open()) {
+        std::cout << "Failed to open " << config_filename << std::endl;
+        return false;
+    }
+    nlohmann::json j = bufferConfig;
+    out_stream << j;
+    out_stream.close();
+    return true;
+}

--- a/src/libYARP_telemetry/src/yarp/telemetry/BufferConfig.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/BufferConfig.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_TELEMETRY_BUFFER_CONFIG_H
+#define YARP_TELEMETRY_BUFFER_CONFIG_H
+
+#include <yarp/telemetry/api.h>
+#include <cstring>
+#include <vector>
+
+namespace yarp::telemetry {
+using dimensions_t = std::vector<size_t>;
+
+using ChannelInfo = std::pair< std::string, dimensions_t >;
+
+struct YARP_telemetry_API BufferConfig {
+    std::string filename{ "" };
+    size_t n_samples{ 0 };
+    double save_period{ 0.010 };
+    size_t data_threshold{ 0 };
+    bool auto_save{ false };
+    bool save_periodically{ false };
+    std::vector<ChannelInfo> channels;
+};
+
+} // yarp::telemetry
+
+bool YARP_telemetry_API bufferConfigFromJson(yarp::telemetry::BufferConfig& bufferConfig, const std::string& config_filename);
+
+bool YARP_telemetry_API bufferConfigToJson(const yarp::telemetry::BufferConfig& bufferConfig, const std::string& config_filename);
+
+#endif

--- a/src/libYARP_telemetry/src/yarp/telemetry/BufferManager.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/BufferManager.h
@@ -79,6 +79,11 @@ public:
 
     void setFileName(const std::string& filename) {
         m_filename = filename;
+    void resize(size_t new_size) {
+        for (auto& [var_name, buff] : m_buffer_map) {
+            buff.resize(new_size);
+        }
+        m_bufferConfig.n_samples = new_size;
         return;
     }
 

--- a/src/libYARP_telemetry/src/yarp/telemetry/BufferManager.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/BufferManager.h
@@ -27,17 +27,16 @@ namespace yarp::telemetry {
 
 using dimensions_t = std::vector<size_t>;
 
-struct ChannelInfo {
-    std::string m_var_name;
-    dimensions_t m_dimensions{ 1,1 };
-};
+using ChannelInfo = std::pair< std::string, dimensions_t >;
 
 struct BufferConfig {
-    size_t n_samples = 0;
-    unsigned int check_period = 10;
-    size_t threshold = 0;
-    bool m_auto_save = false;
-    bool save_periodically = false;
+    std::string filename{ "" };
+    size_t n_samples{ 0 };
+    double save_period{ 0.010 };
+    size_t data_threshold{ 0 };
+    bool auto_save{ false };
+    bool save_periodically{ false };
+    std::vector<ChannelInfo> channels;
 };
 
 
@@ -45,40 +44,51 @@ template<class T>
 class BufferManager {
 
 public:
-    BufferManager() = delete;
-    BufferManager(const BufferConfig& _bufferConfig) : bufferConfig(_bufferConfig) {
-        if (bufferConfig.save_periodically)
-        {
-          std::thread save_thread(&BufferManager::periodicSave, this);
-          save_thread.detach();
-        }
+    BufferManager() = default;
+
+    BufferManager(const BufferConfig& _bufferConfig) {
+        bool ok = configure(_bufferConfig);
+        assert(ok);
     }
 
-    BufferManager(const std::string& filename,
-                  const std::vector<ChannelInfo>& channels,
-                  const BufferConfig& _bufferConfig) : m_filename(filename), bufferConfig(_bufferConfig) {
-        assert(!channels.empty());
-        assert(!filename.empty());
-        auto ret = addChannels(channels);
-        assert(ret == true);
-
-        if (bufferConfig.save_periodically)
-        {
-          std::thread save_thread(&BufferManager::periodicSave, this);
-          save_thread.detach();
-        }
-	}
-
     ~BufferManager() {
-        closing = true;
-        if (bufferConfig.m_auto_save) {
+        m_should_stop_thread = true;
+        if (m_bufferConfig.auto_save) {
             saveToFile();
         }
+    }
+    // This function is used for manual toggling the periodic save, then
+    // if the thread has been started yet in the configuration throught
+    // BufferConfing, it skip
+    bool enablePeriodicSave(double _save_period) {
+        if (!m_thread_running) {
+            m_bufferConfig.save_periodically = true;
+            m_bufferConfig.save_period = _save_period;
+            std::thread save_thread(&BufferManager::periodicSave, this);
+            save_thread.detach();
+            return true;
+        }
+        return false;
+    }
+    bool configure(const BufferConfig& _bufferConfig) {
+        bool ok{ true };
+        m_bufferConfig = _bufferConfig;
+        if (!_bufferConfig.channels.empty()) {
+            ok = ok && addChannels(_bufferConfig.channels);
+        }
+        if (ok && _bufferConfig.save_periodically) {
+            ok = ok && enablePeriodicSave(_bufferConfig.save_period);
+        }
+        // TODO ROLL BACK IN CASE OF FAILURE
+        return ok;
     }
 
 
     void setFileName(const std::string& filename) {
-        m_filename = filename;
+        m_bufferConfig.filename = filename;
+        return;
+    }
+
     void resize(size_t new_size) {
         for (auto& [var_name, buff] : m_buffer_map) {
             buff.resize(new_size);
@@ -89,8 +99,9 @@ public:
 
     bool addChannel(const ChannelInfo& channel) {
         // Probably one day we will have just one map
-        auto ret_buff = m_buffer_map.insert(std::pair<std::string, yarp::telemetry::Buffer<T>>(channel.m_var_name, Buffer<T>(bufferConfig.n_samples)));
-        auto ret_dim =  m_dimensions_map.insert(std::pair<std::string, yarp::telemetry::dimensions_t>(channel.m_var_name, channel.m_dimensions));
+        auto ret_buff = m_buffer_map.insert(std::pair<std::string, yarp::telemetry::Buffer<T>>(channel.first, Buffer<T>(m_bufferConfig.n_samples)));
+        auto ret_dim =  m_dimensions_map.insert(std::pair<std::string, yarp::telemetry::dimensions_t>(channel.first, channel.second));
+        m_bufferConfig.channels.push_back(channel);
         return ret_buff.second && ret_dim.second;
     }
 
@@ -120,15 +131,23 @@ public:
         m_buffer_map.at(var_name).push_back(Record<T>(m_nowFunction(), std::move(elem)));
     }
 
-    bool saveToFile() {
+    bool saveToFile(bool flush_all=true) {
 
         // now we initialize the proto-timeseries structure
         std::vector<matioCpp::Variable> signalsVect;
         // and the matioCpp struct for these signals
+        std::scoped_lock<std::mutex> lock{ m_mutex };
+        // In case of the misconfiguration where the threshold is less than the capacity of buffers
+        // we have to force the flush.
+        flush_all = flush_all || (m_bufferConfig.data_threshold > m_bufferConfig.n_samples);
         for (auto& [var_name, buff] : m_buffer_map) {
-            if (buff.empty())
-            {
+            if (buff.empty()) {
                 std::cout << var_name << " does not contain data, skipping" << std::endl;
+                continue;
+            }
+
+            if (!flush_all && buff.size() < m_bufferConfig.data_threshold) {
+                std::cout << var_name << " does not contain enought data, skipping" << std::endl;
                 continue;
             }
 
@@ -187,10 +206,10 @@ public:
             std::cout << "No available data to be saved" << std::endl;
             return false;
         }
-        matioCpp::Struct timeSeries(m_filename, signalsVect);
+        matioCpp::Struct timeSeries(m_bufferConfig.filename, signalsVect);
         // and finally we write the file
         // since we might save several files, we need to index them
-        std::string new_file = m_filename + "_" + std::to_string(file_index) + ".mat";
+        std::string new_file = m_bufferConfig.filename + "_" + std::to_string(file_index) + ".mat";
         file_index++;
         matioCpp::File file = matioCpp::File::Create(new_file);
         return file.write(timeSeries);
@@ -213,33 +232,27 @@ private:
     }
     void periodicSave()
     {
-        while (!closing)
+        while (!m_should_stop_thread)
         {
-            auto next_step = std::chrono::steady_clock::now() + std::chrono::milliseconds(bufferConfig.check_period);
+            m_thread_running = true;
+            auto next_step = std::chrono::steady_clock::now() + std::chrono::milliseconds(static_cast<uint32_t>(1000*m_bufferConfig.save_period));
 
-            // This loop saves all the variables as soon as one of the variables crosses the threshold
-            if (m_buffer_map.size() > 0) // if there are channels
+            if (!m_buffer_map.empty()) // if there are channels
             {
-                for (auto& [var_name, buff] : m_buffer_map)
-                {
-                    if (buff.size() >= bufferConfig.threshold)
-                    {
-                        saveToFile();
-                        break;
-                    }
-                }
+                saveToFile(false);
             }
             if (std::chrono::steady_clock::now() < next_step)
             {
                 std::this_thread::sleep_until(next_step);
             }
         }
+        m_thread_running = false;
     }
 
-    BufferConfig bufferConfig;
-    bool closing{false};
-    int file_index{0};
-    std::string m_filename;
+    BufferConfig m_bufferConfig;
+    std::atomic<bool> m_should_stop_thread{ false }, m_thread_running{ false };
+    std::mutex m_mutex;
+    int file_index{ 0 };
     std::unordered_map<std::string, Buffer<T>> m_buffer_map;
     std::unordered_map<std::string, dimensions_t> m_dimensions_map;
     std::function<double(void)> m_nowFunction{DefaultClock};

--- a/src/libYARP_telemetry/src/yarp/telemetry/BufferManager.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/BufferManager.h
@@ -11,18 +11,19 @@
 
 #include <yarp/telemetry/Buffer.h>
 #include <nlohmann/json.hpp>
+#include <matioCpp/matioCpp.h>
+
 #include <unordered_map>
 #include <string>
 #include <vector>
 #include <iostream>
+#include <fstream>
 #include <assert.h>
 #include <functional>
 #include <chrono>
-#include <matioCpp/matioCpp.h>
 #include <thread>
 #include <atomic>
 #include <mutex>
-
 
 
 namespace yarp::telemetry {
@@ -41,6 +42,8 @@ struct BufferConfig {
     std::vector<ChannelInfo> channels;
 };
 
+// This expects that the name of the json keyword is the same of the relative variable
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(BufferConfig, filename, n_samples, save_period, data_threshold, auto_save, save_periodically, channels)
 
 template<class T>
 class BufferManager {
@@ -71,6 +74,13 @@ public:
             return true;
         }
         return false;
+    }
+    bool configureFromFile(const std::string& config_filename) {
+        // read a JSON file
+        std::ifstream input_stream(config_filename);
+        nlohmann::json jason_file;
+        input_stream >> jason_file;
+        return configure(jason_file.get<yarp::telemetry::BufferConfig>());
     }
     bool configure(const BufferConfig& _bufferConfig) {
         bool ok{ true };

--- a/src/libYARP_telemetry/src/yarp/telemetry/BufferManager.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/BufferManager.h
@@ -10,6 +10,7 @@
 #define YARP_TELEMETRY_BUFFER_MANAGER_H
 
 #include <yarp/telemetry/Buffer.h>
+#include <nlohmann/json.hpp>
 #include <unordered_map>
 #include <string>
 #include <vector>
@@ -19,8 +20,9 @@
 #include <chrono>
 #include <matioCpp/matioCpp.h>
 #include <thread>
+#include <atomic>
+#include <mutex>
 
-#include <chrono>
 
 
 namespace yarp::telemetry {

--- a/src/libYARP_telemetry/src/yarp/telemetry/BufferManager.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/BufferManager.h
@@ -10,7 +10,8 @@
 #define YARP_TELEMETRY_BUFFER_MANAGER_H
 
 #include <yarp/telemetry/Buffer.h>
-#include <nlohmann/json.hpp>
+#include <yarp/telemetry/BufferConfig.h>
+
 #include <matioCpp/matioCpp.h>
 
 #include <unordered_map>
@@ -27,23 +28,6 @@
 
 
 namespace yarp::telemetry {
-
-using dimensions_t = std::vector<size_t>;
-
-using ChannelInfo = std::pair< std::string, dimensions_t >;
-
-struct BufferConfig {
-    std::string filename{ "" };
-    size_t n_samples{ 0 };
-    double save_period{ 0.010 };
-    size_t data_threshold{ 0 };
-    bool auto_save{ false };
-    bool save_periodically{ false };
-    std::vector<ChannelInfo> channels;
-};
-
-// This expects that the name of the json keyword is the same of the relative variable
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(BufferConfig, filename, n_samples, save_period, data_threshold, auto_save, save_periodically, channels)
 
 template<class T>
 class BufferManager {
@@ -75,13 +59,7 @@ public:
         }
         return false;
     }
-    bool configureFromFile(const std::string& config_filename) {
-        // read a JSON file
-        std::ifstream input_stream(config_filename);
-        nlohmann::json jason_file;
-        input_stream >> jason_file;
-        return configure(jason_file.get<yarp::telemetry::BufferConfig>());
-    }
+
     bool configure(const BufferConfig& _bufferConfig) {
         bool ok{ true };
         m_bufferConfig = _bufferConfig;
@@ -95,6 +73,9 @@ public:
         return ok;
     }
 
+    BufferConfig getBufferConfig() const {
+        return m_bufferConfig;
+    }
 
     void setFileName(const std::string& filename) {
         m_bufferConfig.filename = filename;


### PR DESCRIPTION
- The `ChannelInfo` has been changed from a struct of two elements to a
`std::pair`, in order to be easily handled with the JSON file conf.
- All the flags, options of the BufferManager have been put in the BufferConfig
- The empty constructor is allowed now, for this we added all the functions
needed for configuring a default BufferManager(It fixes #60)

- The mutex has been added in `saveToFile`(partially address #9)
- Now the periodicSave, saves only the variables that go above the
data_treshold specified
- Fixes the bug of not saving when the threshold > n_samples(fixes #61 )
- It has been added the configuration from JSON file using [this library](https://github.com/nlohmann/json) with relative example (it fixes #39) 
- It add the possibility to save `BufferConfig` to json file(it fixes #68)
- It add `nlhomann_json v3.9.0` as dependency via `FetchContent`( it fixes #66)
Here is an example of JSON file for configuring the `BufferManager`:

```json
{
    "filename": "buffer_manager_test_conf_file",
    "n_samples": 20,
    "save_period": 1.0,
    "data_threshold": 10,
    "auto_save": true,
    "save_periodically": true,
    "channels": [
        ["one",[1,1]],
        ["two",[1,1]]
    ]
  }

```

For now we used the json library just importing the `json.hpp` file, this has to be in the future to an "extern" folder or better with the cmake FetchContent mechanism.

Please review code.



cc @traversaro @S-Dafarra @GiulioRomualdi