### PR TITLE
Add valgrind to the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,4 +181,14 @@ jobs:
         cd build
         export PATH=$PATH:${GITHUB_WORKSPACE}/install/bin:${GITHUB_WORKSPACE}/install/deps/bin:/c/robotology/vcpkg/installed/x64-windows/bin:/c/robotology/vcpkg/installed/x64-windows/debug/bin
         ctest --output-on-failure -C ${{ matrix.build_type }} .
+    - name: Run examples with valgrind [Ubuntu]
+      if: matrix.os == 'ubuntu-latest'
+      shell: bash
+      run: |
+        cd build/bin
+        valgrind --tool=memcheck --leak-check=full ./circular_buffer_example
+        valgrind --tool=memcheck --leak-check=full ./telemetry_buffer_example
+        valgrind --tool=memcheck --leak-check=full ./telemetry_buffer_manager_conf_file_example
+        valgrind --tool=memcheck --leak-check=full ./telemetry_buffer_manager_example
+        valgrind --tool=memcheck --leak-check=full ./telemetry_buffer_periodic_save
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         # Workaround for https://github.com/robotology/robotology-superbuild/issues/565
         brew upgrade  python@3.9 || brew link --overwrite python@3.9
         brew upgrade
-        brew install cmake libmatio ace eigen boost
+        brew install cmake libmatio ace eigen boost valgrind
 
     - name: Dependencies [Windows]
       if: matrix.os == 'windows-latest'
@@ -140,7 +140,7 @@ jobs:
         mkdir -p build
         cd build
         cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-              -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install -DBUILD_TESTING:BOOL=ON ..
+              -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install -DBUILD_TESTING:BOOL=ON -DYARP_VALGRIND_TESTS:BOOL=ON ..
 
     - name: Configure [Windows]
       # Use bash also on Windows (otherwise cd, mkdir, ... do not work)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         # Workaround for https://github.com/robotology/robotology-superbuild/issues/565
         brew upgrade  python@3.9 || brew link --overwrite python@3.9
         brew upgrade
-        brew install cmake libmatio ace eigen boost valgrind
+        brew install cmake libmatio ace eigen boost
 
     - name: Dependencies [Windows]
       if: matrix.os == 'windows-latest'
@@ -140,7 +140,15 @@ jobs:
         mkdir -p build
         cd build
         cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-              -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install -DBUILD_TESTING:BOOL=ON -DYARP_VALGRIND_TESTS:BOOL=ON ..
+              -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install -DBUILD_TESTING:BOOL=ON ..
+
+    - name: Enable Valgrind tests [Ubuntu]
+      if: matrix.os == 'ubuntu-latest'
+      shell: bash
+      run: |
+        cd build
+        cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install -DYARP_VALGRIND_TESTS:BOOL=ON ..
+
 
     - name: Configure [Windows]
       # Use bash also on Windows (otherwise cd, mkdir, ... do not work)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,46 @@ add_subdirectory(src)
 option(BUILD_TESTING "Create tests using CMake" OFF)
 option(YARP_TELEMETRY_USES_SYSTEM_Catch2 OFF)
 
+##############################
+########### Test #############
+##############################
+
+# Just copied from yarp
+cmake_dependent_option(YARP_VALGRIND_TESTS
+                       "Run YARP tests under Valgrind" OFF
+                       "BUILD_TESTING" OFF)
+mark_as_advanced(YARP_VALGRIND_TESTS)
+
+if(YARP_VALGRIND_TESTS)
+  find_program(VALGRIND_EXECUTABLE NAMES valgrind)
+  mark_as_advanced(VALGRIND_EXECUTABLE)
+
+  if(VALGRIND_EXECUTABLE)
+    set(VALGRIND_OPTIONS "--tool=memcheck --leak-check=full"
+      CACHE STRING "Valgrind options (--error-exitcode=1 will be appended)")
+    mark_as_advanced(VALGRIND_OPTIONS)
+    separate_arguments(VALGRIND_OPTIONS UNIX_COMMAND "${VALGRIND_OPTIONS}")
+    set(VALGRIND_COMMAND "${VALGRIND_EXECUTABLE}" ${VALGRIND_OPTIONS} --error-exitcode=1 --fullpath-after=${CMAKE_SOURCE_DIR}/)
+  else()
+    message(SEND_ERROR "Valgrind executable not found")
+  endif()
+endif()
+
+unset(YARP_TEST_LAUNCHER)
+set(YARP_TEST_TIMEOUT_DEFAULT_VALGRIND 300)
+if(DEFINED VALGRIND_COMMAND)
+  set(YARP_TEST_LAUNCHER ${VALGRIND_COMMAND})
+  # The default timeout is not enough when running under valgrind
+  if(YARP_TEST_TIMEOUT EQUAL YARP_TEST_TIMEOUT_DEFAULT)
+    set_property(CACHE YARP_TEST_TIMEOUT PROPERTY VALUE ${YARP_TEST_TIMEOUT_DEFAULT_VALGRIND})
+  endif()
+else()
+  if(YARP_TEST_TIMEOUT EQUAL YARP_TEST_TIMEOUT_DEFAULT_VALGRIND)
+    set_property(CACHE YARP_TEST_TIMEOUT PROPERTY VALUE ${YARP_TEST_TIMEOUT_DEFAULT})
+  endif()
+endif()
+
+
 if(BUILD_TESTING)
   if(YARP_TELEMETRY_USES_SYSTEM_Catch2)
     find_package(Catch2 REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,10 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_C_EXTENSIONS OFF)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.19)
+  cmake_policy(SET CMP0111 NEW)
+endif()
+
 
 # Enable RPATH support for installed binaries and libraries
 include(AddInstallRPATHSupport)

--- a/src/libYARP_telemetry/src/yarp/telemetry/BufferManager.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/BufferManager.h
@@ -81,11 +81,12 @@ public:
      * @return true on success, false otherwise.
      */
     bool enablePeriodicSave(double _save_period) {
-        if (!m_save_thread_ptr) {
+        // If it is not joinable means it is not running
+        if (!m_save_thread.joinable()) {
             m_bufferConfig.save_periodically = true;
             m_bufferConfig.save_period = _save_period;
-            m_save_thread_ptr = std::make_unique<std::thread>(&BufferManager::periodicSave, this);
-            m_save_thread_ptr->detach();
+            m_save_thread = std::thread(&BufferManager::periodicSave, this);
+            m_save_thread.detach();
             return true;
         }
         return false;
@@ -339,7 +340,7 @@ private:
     std::unordered_map<std::string, Buffer<T>> m_buffer_map;
     std::unordered_map<std::string, dimensions_t> m_dimensions_map;
     std::function<double(void)> m_nowFunction{DefaultClock};
-    std::unique_ptr<std::thread> m_save_thread_ptr{ nullptr };
+    std::thread m_save_thread;
 };
 
 } // yarp::telemetry

--- a/src/libYARP_telemetry/src/yarp/telemetry/BufferManager.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/BufferManager.h
@@ -67,6 +67,9 @@ public:
      */
     ~BufferManager() {
         m_should_stop_thread = true;
+        if (m_save_thread.joinable()) {
+            m_save_thread.join();
+        }
         if (m_bufferConfig.auto_save) {
             saveToFile();
         }
@@ -86,7 +89,6 @@ public:
             m_bufferConfig.save_periodically = true;
             m_bufferConfig.save_period = _save_period;
             m_save_thread = std::thread(&BufferManager::periodicSave, this);
-            m_save_thread.detach();
             return true;
         }
         return false;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,6 +4,10 @@
 # This software may be modified and distributed under the terms of the
 # BSD-3-Clause license. See the accompanying LICENSE file for details.
 
+if(YARP_VALGRIND_TESTS)
+  add_definitions(-DWITH_VALGRIND)
+endif()
+
 add_executable(bufferManager_test BufferManagerTest.cpp)
 target_link_libraries(bufferManager_test PRIVATE Catch2::Catch2
                                                  matioCpp::matioCpp 
@@ -15,4 +19,17 @@ target_link_libraries(bufferManager_test PRIVATE Catch2::Catch2
 
 include(CTest)
 include(Catch)
-catch_discover_tests(bufferManager_test)
+function(yarp_catch_discover_tests _target)
+  # Workaround to force catch_discover_tests to run tests under valgrind
+  set_property(TARGET ${_target} PROPERTY CROSSCOMPILING_EMULATOR "${YARP_TEST_LAUNCHER}")
+  catch_discover_tests(
+    ${_target}
+    EXTRA_ARGS "-s" "--use-colour" "yes"
+    PROPERTIES
+      TIMEOUT ${YARP_TEST_TIMEOUT}
+      SKIP_RETURN_CODE 254
+    )
+endfunction()
+
+
+yarp_catch_discover_tests(bufferManager_test)


### PR DESCRIPTION
This PR adds Valgrind to the unit tests and examples that run in the CI(for the Ubuntu part).

It fixes #79 
It fixes #64 

Please review code
(MERGE AFTER #78 )