### PR TITLE
telemetryDeviceDumper: add first draft

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ endif()
 
 
 set(YARP_FORCE_DYNAMIC_PLUGINS TRUE CACHE INTERNAL "${PROJECT_NAME} is always built with dynamic plugins")
-find_package(YARP 3.4 COMPONENTS conf os REQUIRED)
+find_package(YARP 3.4 COMPONENTS conf dev os REQUIRED)
 # Use the same build options as YARP
 set(BUILD_SHARED_LIBS ${YARP_IS_SHARED_LIBRARY})
 set(CMAKE_C_FLAGS ${YARP_C_FLAGS})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,3 +6,4 @@
 
 add_subdirectory(libYARP_telemetry)
 add_subdirectory(examples)
+add_subdirectory(telemetryDeviceDumper)

--- a/src/telemetryDeviceDumper/CMakeLists.txt
+++ b/src/telemetryDeviceDumper/CMakeLists.txt
@@ -15,11 +15,11 @@ if(ENABLE_telemetryDeviceDumper)
   yarp_add_plugin(yarp_telemetryDeviceDumper)
 
   target_sources(yarp_telemetryDeviceDumper PRIVATE TelemetryDeviceDumper.cpp
-                                               TelemetryDeviceDumper.h)
+                                                    TelemetryDeviceDumper.h)
 
   target_link_libraries(yarp_telemetryDeviceDumper PRIVATE YARP::YARP_os
-                                                      YARP::YARP_dev
-                                                      YARP::YARP_telemetry)
+                                                           YARP::YARP_dev
+                                                           YARP::YARP_telemetry)
   list(APPEND YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS YARP_os
                                                       YARP_dev
                                                       YARP_telemetry)

--- a/src/telemetryDeviceDumper/CMakeLists.txt
+++ b/src/telemetryDeviceDumper/CMakeLists.txt
@@ -1,0 +1,37 @@
+# Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
+# All rights reserved.
+#
+# This software may be modified and distributed under the terms of the
+# BSD-3-Clause license. See the accompanying LICENSE file for details.
+
+yarp_prepare_plugin(telemetryDeviceDumper
+                    CATEGORY device
+                    TYPE yarp::telemetry::TelemetryDeviceDumper
+                    INCLUDE TelemetryDeviceDumper.h
+                    DEFAULT ON)
+
+if(ENABLE_telemetryDeviceDumper)
+
+  yarp_add_plugin(yarp_telemetryDeviceDumper)
+
+  target_sources(yarp_telemetryDeviceDumper PRIVATE TelemetryDeviceDumper.cpp
+                                               TelemetryDeviceDumper.h)
+
+  target_link_libraries(yarp_telemetryDeviceDumper PRIVATE YARP::YARP_os
+                                                      YARP::YARP_dev
+                                                      YARP::YARP_telemetry)
+  list(APPEND YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS YARP_os
+                                                      YARP_dev
+                                                      YARP_telemetry)
+
+  yarp_install(TARGETS yarp_telemetryDeviceDumper
+               EXPORT YARP_${YARP_PLUGIN_MASTER}
+               COMPONENT ${YARP_PLUGIN_MASTER}
+               LIBRARY DESTINATION ${YARP_DYNAMIC_PLUGINS_INSTALL_DIR}
+               ARCHIVE DESTINATION ${YARP_STATIC_PLUGINS_INSTALL_DIR}
+               YARP_INI DESTINATION ${YARP_PLUGIN_MANIFESTS_INSTALL_DIR})
+
+  set(YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS ${YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS} PARENT_SCOPE)
+
+  set_property(TARGET yarp_telemetryDeviceDumper PROPERTY FOLDER "Plugins/Device")
+endif()

--- a/src/telemetryDeviceDumper/TelemetryDeviceDumper.cpp
+++ b/src/telemetryDeviceDumper/TelemetryDeviceDumper.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+#include "TelemetryDeviceDumper.h"
+
+using namespace yarp::telemetry;
+
+TelemetryDeviceDumper::TelemetryDeviceDumper() : yarp::os::PeriodicThread(0) {
+    // TODO
+}
+
+TelemetryDeviceDumper::~TelemetryDeviceDumper() {
+    // TODO
+}
+
+bool TelemetryDeviceDumper::close() {
+    // TODO
+    return true;
+}
+
+bool TelemetryDeviceDumper::open(yarp::os::Searchable& config) {
+    // TODO
+    return true;
+}
+
+bool TelemetryDeviceDumper::attachAll(const yarp::dev::PolyDriverList& device2attach) {
+    // TODO
+    return true;
+}
+
+bool TelemetryDeviceDumper::detachAll() {
+    // TODO
+    return true;
+}
+
+bool TelemetryDeviceDumper::attach(yarp::dev::PolyDriver* poly) {
+    // TODO
+    return true;
+}
+
+bool TelemetryDeviceDumper::detach() {
+    // TODO
+    return true;
+}
+
+// PeriodicThread
+bool TelemetryDeviceDumper::threadInit() {
+    // TODO
+    return true;
+}
+
+void TelemetryDeviceDumper::threadRelease() {
+    // TODO
+    return;
+}
+
+void TelemetryDeviceDumper::run() {
+    // TODO
+    return;
+}
+

--- a/src/telemetryDeviceDumper/TelemetryDeviceDumper.cpp
+++ b/src/telemetryDeviceDumper/TelemetryDeviceDumper.cpp
@@ -6,10 +6,75 @@
  * BSD-3-Clause license. See the accompanying LICENSE file for details.
  */
 #include "TelemetryDeviceDumper.h"
+#include <array>
 
 using namespace yarp::telemetry;
+using namespace yarp::os;
 
-TelemetryDeviceDumper::TelemetryDeviceDumper() : yarp::os::PeriodicThread(0) {
+constexpr double period_thread{ 0.010 };
+constexpr std::array<char*, 6> partsArray{ "head","torso","left_arm","right_arm","left_leg","right_leg" };
+
+
+bool RemoteControlGateway::open(const std::string& robot, const std::string& part, const std::string& moduleName) {
+    yarp::os::Property conf{ {"device", yarp::os::Value("remote_controlboard")},
+                             {"remote", yarp::os::Value("/" + robot + "/" + part)},
+                             {"local",  yarp::os::Value("/" + moduleName + "/" + part + "/remoteControlBoard")} };
+
+
+    m_remoteControlBoard = std::make_unique<yarp::dev::PolyDriver>();
+
+    bool ok = m_remoteControlBoard->open(conf);
+    if (!ok) {
+        yError() << "RemoteControlGateway: failed to open the remote control board for part" << part;
+        return false;
+    }
+    ok = ok && m_remoteControlBoard->view(m_iEnc);
+    int num_axes{ 0 };
+    ok = ok && m_iEnc->getAxes(&num_axes);
+
+    if (ok) {
+        m_encs_vec.resize(num_axes);
+        m_encs_speeds_vec.resize(num_axes);
+        m_encs_acc_vec.resize(num_axes);
+        
+        // This is the buffer manager configuration
+        // For now it is just hard coded.
+        yarp::telemetry::BufferConfig bufferConfig;
+        bufferConfig.channels = { {"encoders",{1,(size_t)num_axes}},
+                                  {"encoder_speeds",{1,(size_t)num_axes}},
+                                  {"encoder_accelerations",{1,(size_t)num_axes}} };
+        bufferConfig.filename = moduleName + "_" + robot + "_" + part;
+        bufferConfig.n_samples = 1000;
+        bufferConfig.save_period = 1.0;
+        bufferConfig.data_threshold = 300;
+        bufferConfig.save_periodically = true;
+
+        ok = ok && m_bm.configure(bufferConfig);
+    }
+
+    return ok;
+}
+
+void RemoteControlGateway::readAndPush() {
+    if (!m_iEnc) {
+        return;
+    }
+    bool ok = m_iEnc->getEncoders(m_encs_vec.data());
+    ok = ok && m_iEnc->getEncoderSpeeds(m_encs_speeds_vec.data());
+    ok = ok && m_iEnc->getEncoderAccelerations(m_encs_acc_vec.data());
+    if (ok) {
+        m_bm.push_back(m_encs_vec, "encoders");
+        m_bm.push_back(m_encs_speeds_vec, "encoder_speeds");
+        m_bm.push_back(m_encs_acc_vec, "encoder_accelerations");
+    }
+}
+
+void RemoteControlGateway::close() {
+    m_remoteControlBoard->close();
+}
+
+// For now also the period is harcoded, it can be configured
+TelemetryDeviceDumper::TelemetryDeviceDumper() : yarp::os::PeriodicThread(period_thread) {
     // TODO
 }
 
@@ -18,13 +83,39 @@ TelemetryDeviceDumper::~TelemetryDeviceDumper() {
 }
 
 bool TelemetryDeviceDumper::close() {
-    // TODO
+    for (auto& r : m_rcg_map) {
+        r.second.close();
+    }
+    PeriodicThread::stop();
     return true;
 }
 
 bool TelemetryDeviceDumper::open(yarp::os::Searchable& config) {
-    // TODO
-    return true;
+    auto robot = config.check("robot", Value("icubSim")).asString();
+    auto name = config.check("name", Value("telemetryDeviceDumper")).asString();
+
+    auto partsBot = config.find("parts").asList();
+    if (!partsBot || partsBot->isNull())
+    {
+        yError() << "telemetryDeviceDumper: missing parts parameter, please specify as list";
+        return false;
+    }
+
+    for (size_t i = 0; i < partsBot->size(); i++) {
+        auto partStr = partsBot->get(i).asString();
+        if (partsArray.end() == std::find(partsArray.begin(), partsArray.end(), partStr))
+        {
+            yError() << "telemetryDeviceDumper: the part" << partStr << "is not available";
+            return false;
+        }
+        if (!m_rcg_map[partStr].open(robot, partStr, name))
+        {
+            yError() << "telemetryDeviceDumper: failed to open one remote control gateway.. closing.";
+            return false;
+        }
+    }
+
+    return PeriodicThread::start();
 }
 
 bool TelemetryDeviceDumper::attachAll(const yarp::dev::PolyDriverList& device2attach) {
@@ -59,7 +150,9 @@ void TelemetryDeviceDumper::threadRelease() {
 }
 
 void TelemetryDeviceDumper::run() {
-    // TODO
+    for (auto& rcg : m_rcg_map) {
+        rcg.second.readAndPush();
+    }
     return;
 }
 

--- a/src/telemetryDeviceDumper/TelemetryDeviceDumper.h
+++ b/src/telemetryDeviceDumper/TelemetryDeviceDumper.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_TELEMETRY_TELEMETRYDEVICEDUMPER_H
+#define YARP_TELEMETRY_TELEMETRYDEVICEDUMPER_H
+
+#include <yarp/dev/DeviceDriver.h>
+#include <yarp/dev/IWrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
+#include <yarp/os/PeriodicThread.h>
+#include <yarp/telemetry/BufferManager.h>
+
+namespace yarp::telemetry {
+/**
+ * @brief FILL DOCUMENTATION
+ *
+ */
+class TelemetryDeviceDumper : public yarp::dev::DeviceDriver,
+                              public yarp::dev::IWrapper,
+                              public yarp::dev::IMultipleWrapper,
+                              public yarp::os::PeriodicThread
+{
+public:
+    TelemetryDeviceDumper();
+    ~TelemetryDeviceDumper() override;
+
+    //DeviceDriver
+    bool close() override;
+    /**
+        * Configure with a set of options.
+        * @param config The options to use
+        * @return true iff the object could be configured.
+        */
+    bool open(yarp::os::Searchable& config) override;
+
+    // IMultipleWrapper interface
+    bool        attachAll(const yarp::dev::PolyDriverList& device2attach) override;
+
+    bool        detachAll() override;
+
+    // IWrapper interface
+    bool        attach(yarp::dev::PolyDriver* poly) override;
+
+    bool        detach() override;
+
+    // PeriodicThread
+    bool threadInit() override;
+
+    void threadRelease() override;
+
+    void run() override;
+
+};
+}
+
+#endif // YARP_TELEMETRY_TELEMETRYDEVICEDUMPER_H

--- a/src/telemetryDeviceDumper/TelemetryDeviceDumper.h
+++ b/src/telemetryDeviceDumper/TelemetryDeviceDumper.h
@@ -12,10 +12,35 @@
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/IWrapper.h>
 #include <yarp/dev/IMultipleWrapper.h>
+#include <yarp/dev/IEncoders.h>
+#include <yarp/dev/PolyDriver.h>
+#include <yarp/os/LogStream.h>
 #include <yarp/os/PeriodicThread.h>
 #include <yarp/telemetry/BufferManager.h>
 
+#include <unordered_map>
+#include <string>
+#include <memory>
+#include <vector>
+
 namespace yarp::telemetry {
+
+/**
+ * @brief FILL DOCUMENTATION
+ *
+ */
+struct RemoteControlGateway {
+    std::unique_ptr<yarp::dev::PolyDriver> m_remoteControlBoard{ nullptr };
+    yarp::telemetry::BufferManager<double> m_bm;
+    yarp::dev::IEncoders* m_iEnc{ nullptr };
+    std::vector<double> m_encs_vec, m_encs_speeds_vec, m_encs_acc_vec;
+
+    bool open(const std::string& robot, const std::string& part, const std::string& moduleName = "telemetryDeviceDumper");
+
+    void readAndPush();
+
+    void close();
+};
 /**
  * @brief FILL DOCUMENTATION
  *
@@ -54,6 +79,9 @@ public:
     void threadRelease() override;
 
     void run() override;
+
+private:
+    std::unordered_map<std::string,yarp::telemetry::RemoteControlGateway> m_rcg_map;
 
 };
 }


### PR DESCRIPTION
This addresses #15 

I made it `IWrapper`/`IMultipleWrapper` but we can discuss the use cases (cc @AlexAntn @S-Dafarra @traversaro )


@AlexAntn and I implemented the first working version

For now it dumps the encoders, the encoders' speed and accelerations for the specified parts of the specified robot.
Here is an example of usage:

```bash
$ yarpdev --device telemetryDeviceDumper --parts "(head left_arm right_leg)"
```
(if not specified `icubSim` is the default value for `robot`)

And here are the file produced:
```
-a----          3/1/2021   3:20 PM          55696 telemetryDeviceDumper_icubSim_head_1614608427.576625.mat
-a----          3/1/2021   3:20 PM          62584 telemetryDeviceDumper_icubSim_head_1614608431.579932.mat
-a----          3/1/2021   3:20 PM          62592 telemetryDeviceDumper_icubSim_head_1614608435.584401.mat
-a----          3/1/2021   3:20 PM          61184 telemetryDeviceDumper_icubSim_head_1614608439.589465.mat
-a----          3/1/2021   3:20 PM         141784 telemetryDeviceDumper_icubSim_left_arm_1614608427.805764.mat
-a----          3/1/2021   3:20 PM         149944 telemetryDeviceDumper_icubSim_left_arm_1614608431.807887.mat
-a----          3/1/2021   3:20 PM         149944 telemetryDeviceDumper_icubSim_left_arm_1614608435.811885.mat
-a----          3/1/2021   3:20 PM          62584 telemetryDeviceDumper_icubSim_right_leg_1614608428.033400.mat
-a----          3/1/2021   3:20 PM          62584 telemetryDeviceDumper_icubSim_right_leg_1614608432.036649.mat
-a----          3/1/2021   3:20 PM          62584 telemetryDeviceDumper_icubSim_right_leg_1614608436.041214.mat
```

and here it is the content of `telemetryDeviceDumper_icubSim_head` for example:
```

telemetryDeviceDumper_icubSim_head = 

  struct with fields:

                 encoders: [1×1 struct]
           encoder_speeds: [1×1 struct]
    encoder_accelerations: [1×1 struct]

telemetryDeviceDumper_icubSim_head.encoders =

  struct with fields:

          data: [1×6×356 double]
    dimensions: [1 6 356]
          name: 'encoders'
    timestamps: [1×356 double]

```

And so on.

I think we achieved the first milestone, improvements can be made(e.g. the configuration of the buffermanager is hardcoded, we can use the configuration from json)