### PR TITLE
 telemetryDeviceDumper: first draft attaching multiple controlboards and use the remapper

### DIFF
--- a/src/telemetryDeviceDumper/CMakeLists.txt
+++ b/src/telemetryDeviceDumper/CMakeLists.txt
@@ -14,6 +14,10 @@ if(ENABLE_telemetryDeviceDumper)
 
   yarp_add_plugin(yarp_telemetryDeviceDumper)
 
+  if(MSVC)
+    add_definitions(-D_USE_MATH_DEFINES)
+  endif()
+
   target_sources(yarp_telemetryDeviceDumper PRIVATE TelemetryDeviceDumper.cpp
                                                     TelemetryDeviceDumper.h)
 

--- a/src/telemetryDeviceDumper/TelemetryDeviceDumper.cpp
+++ b/src/telemetryDeviceDumper/TelemetryDeviceDumper.cpp
@@ -101,7 +101,7 @@ bool TelemetryDeviceDumper::loadSettingsFromConfig(yarp::os::Searchable& config)
 }
 
 bool TelemetryDeviceDumper::open(yarp::os::Searchable& config) {
-    
+
     std::lock_guard<std::mutex> guard(this->deviceMutex);
 
     bool ok;
@@ -206,13 +206,13 @@ bool TelemetryDeviceDumper::configBufferManager(yarp::os::Searchable& conf) {
     // This is the buffer manager configuration
     yarp::telemetry::BufferConfig bufferConfig;
     bool ok{ true };
-    ok = ok && bufferManager.addChannel({ "encoders", {1, jointPos.size()} });
+    ok = ok && bufferManager.addChannel({ "encoders", {jointPos.size(), 1} });
     if (ok && settings.logJointVelocity) {
-        ok = ok && bufferManager.addChannel({ "velocity", {1, jointVel.size()} });
+        ok = ok && bufferManager.addChannel({ "velocity", {jointVel.size(), 1} });
     }
 
     if (ok && settings.logJointAcceleration) {
-        ok = ok && bufferManager.addChannel({ "acceleration", {1, jointAcc.size()} });
+        ok = ok && bufferManager.addChannel({ "acceleration", {jointAcc.size(), 1} });
     }
 
     // TODO: some settings from the ini are duplicated respect to the settings specified in the json file

--- a/src/telemetryDeviceDumper/TelemetryDeviceDumper.cpp
+++ b/src/telemetryDeviceDumper/TelemetryDeviceDumper.cpp
@@ -92,6 +92,11 @@ bool TelemetryDeviceDumper::loadSettingsFromConfig(yarp::os::Searchable& config)
         settings.experimentName = prop.find(experimentName.c_str()).asString();
     }
 
+    std::string path = "path";
+    if (prop.check(path.c_str()) && prop.find(path.c_str()).isString()) {
+        settings.path = prop.find(path.c_str()).asString();
+    }
+
     return true;
 }
 
@@ -210,17 +215,17 @@ bool TelemetryDeviceDumper::configBufferManager(yarp::os::Searchable& conf) {
         ok = ok && bufferManager.addChannel({ "acceleration", {1, jointAcc.size()} });
     }
 
-    bufferConfig.filename = settings.experimentName;
-    
-    // TODO add joint names via description field to be added to the API
+    // TODO: some settings from the ini are duplicated respect to the settings specified in the json file
 
-    // TODO set path where to log data, it has to be done in the API
+    bufferConfig.filename = settings.experimentName;
+    bufferConfig.path = settings.path;
 
     // TODO for now it is just hardcoded
     bufferConfig.n_samples = 1000;
     bufferConfig.save_period = 1.0;
     bufferConfig.data_threshold = 300;
     bufferConfig.save_periodically = true;
+    bufferConfig.description_list = jointNames;
 
     ok = ok && bufferManager.configure(bufferConfig);
 
@@ -249,7 +254,7 @@ bool TelemetryDeviceDumper::detachAll()
     {
         stop();
     }
-    return  this->remappedControlBoardInterfaces.multwrap->detachAll();;
+    return  this->remappedControlBoardInterfaces.multwrap->detachAll();
 }
 
 bool TelemetryDeviceDumper::close()
@@ -314,6 +319,7 @@ void TelemetryDeviceDumper::readSensors()
     }
     if (settings.useRadians) {
         // TODO check if it is safe to call transform on empty vectors.
+        // TODO handle prismatic joints.
         convertVectorFromDegreesToRadians(jointPos);
         convertVectorFromDegreesToRadians(jointVel);
         convertVectorFromDegreesToRadians(jointAcc);

--- a/src/telemetryDeviceDumper/TelemetryDeviceDumper.cpp
+++ b/src/telemetryDeviceDumper/TelemetryDeviceDumper.cpp
@@ -221,8 +221,8 @@ bool TelemetryDeviceDumper::configBufferManager(yarp::os::Searchable& conf) {
     bufferConfig.path = settings.path;
 
     // TODO for now it is just hardcoded
-    bufferConfig.n_samples = 1000;
-    bufferConfig.save_period = 1.0;
+    bufferConfig.n_samples = 100000;
+    bufferConfig.save_period = 120.0;
     bufferConfig.data_threshold = 300;
     bufferConfig.save_periodically = true;
     bufferConfig.description_list = jointNames;

--- a/src/telemetryDeviceDumper/TelemetryDeviceDumper.h
+++ b/src/telemetryDeviceDumper/TelemetryDeviceDumper.h
@@ -33,6 +33,7 @@ struct TelemetryDeviceDumperSettings {
     bool logJointAcceleration{ false };
     bool useRadians{ false };
     std::string experimentName{"telemetryDeviceDumper"};
+    std::string path{ "" };
 };
 /**
  * @brief FILL DOCUMENTATION

--- a/src/telemetryDeviceDumper/TelemetryDeviceDumper.h
+++ b/src/telemetryDeviceDumper/TelemetryDeviceDumper.h
@@ -22,31 +22,24 @@
 #include <string>
 #include <memory>
 #include <vector>
+#include <mutex>
+#include <atomic>
 
 namespace yarp::telemetry {
 
-/**
- * @brief FILL DOCUMENTATION
- *
- */
-struct RemoteControlGateway {
-    std::unique_ptr<yarp::dev::PolyDriver> m_remoteControlBoard{ nullptr };
-    yarp::telemetry::BufferManager<double> m_bm;
-    yarp::dev::IEncoders* m_iEnc{ nullptr };
-    std::vector<double> m_encs_vec, m_encs_speeds_vec, m_encs_acc_vec;
 
-    bool open(const std::string& robot, const std::string& part, const std::string& moduleName = "telemetryDeviceDumper");
-
-    void readAndPush();
-
-    void close();
+struct TelemetryDeviceDumperSettings {
+    bool logJointVelocity{ false };
+    bool logJointAcceleration{ false };
+    bool useRadians{ false };
+    std::string experimentName{"telemetryDeviceDumper"};
 };
 /**
  * @brief FILL DOCUMENTATION
  *
  */
 class TelemetryDeviceDumper : public yarp::dev::DeviceDriver,
-                              public yarp::dev::IWrapper,
+                              //public yarp::dev::IWrapper,
                               public yarp::dev::IMultipleWrapper,
                               public yarp::os::PeriodicThread
 {
@@ -69,19 +62,35 @@ public:
     bool        detachAll() override;
 
     // IWrapper interface
-    bool        attach(yarp::dev::PolyDriver* poly) override;
+    //bool        attach(yarp::dev::PolyDriver* poly) override;
 
-    bool        detach() override;
-
-    // PeriodicThread
-    bool threadInit() override;
-
-    void threadRelease() override;
+    //bool        detach() override;
 
     void run() override;
 
 private:
-    std::unordered_map<std::string,yarp::telemetry::RemoteControlGateway> m_rcg_map;
+
+    bool loadSettingsFromConfig(yarp::os::Searchable& config);
+    bool attachAllControlBoards(const yarp::dev::PolyDriverList& p_list);
+    bool openRemapperControlBoard(yarp::os::Searchable& config);
+    void readSensors();
+    void resizeBuffers(int size);
+    bool configBufferManager(yarp::os::Searchable& config);
+    /** Remapped controlboard containg the axes for which the joint torques are estimated */
+    yarp::dev::PolyDriver remappedControlBoard;
+    struct
+    {
+        yarp::dev::IEncoders* encs;
+        yarp::dev::IMultipleWrapper* multwrap;
+    } remappedControlBoardInterfaces;
+
+    std::mutex deviceMutex;
+    std::atomic<bool> correctlyConfigured{ false }, sensorsReadCorrectly{false};
+    std::vector<double> jointPos, jointVel, jointAcc;
+    std::vector<std::string> jointNames;
+    TelemetryDeviceDumperSettings settings;
+    yarp::telemetry::BufferManager<double> bufferManager;
+
 
 };
 }

--- a/src/telemetryDeviceDumper/app/telelmetryDeviceDumper.xml
+++ b/src/telemetryDeviceDumper/app/telelmetryDeviceDumper.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="telemetryDeviceDumper" type="telemetryDeviceDumper">
+        <param name="axesNames">(torso_pitch,torso_roll,torso_yaw,neck_pitch, neck_roll,neck_yaw,l_shoulder_pitch,l_shoulder_roll,l_shoulder_yaw,l_elbow,l_wrist_prosup,l_wrist_pitch,l_wrist_yaw,r_shoulder_pitch,r_shoulder_roll,r_shoulder_yaw,r_elbow,r_wrist_prosup,r_wrist_pitch,r_wrist_yaw,l_hip_pitch,l_hip_roll,l_hip_yaw,l_knee,l_ankle_pitch,l_ankle_roll,r_hip_pitch,r_hip_roll,r_hip_yaw,r_knee,r_ankle_pitch,r_ankle_roll)</param>
+        <param name="logJointVelocity">true</param>
+        <param name="logJointAcceleration">true</param>
+        <param name="experimentName">test_telemetry</param>
+        <param name="path">/home/icub/test_telemetry/</param>
+
+        <action phase="startup" level="15" type="attach">
+            <paramlist name="networks">
+                <!-- motorcontrol and virtual torque sensors -->
+                <elem name="left_lower_leg">left_leg-eb7-j4_5-mc</elem>
+                <elem name="right_lower_leg">right_leg-eb9-j4_5-mc</elem>
+                <elem name="left_upper_leg">left_leg-eb6-j0_3-mc</elem>
+                <elem name="right_upper_leg">right_leg-eb8-j0_3-mc</elem>
+                <elem name="torso">torso-eb5-j0_2-mc</elem>
+                <elem name="right_lower_arm">right_arm-eb27-j4_7-mc</elem>
+                <elem name="left_lower_arm">left_arm-eb24-j4_7-mc</elem>
+                <elem name="right_upper_arm">right_arm-eb3-j0_3-mc</elem>
+                <elem name="left_upper_arm">left_arm-eb1-j0_3-mc</elem>
+                <elem name="head-j0">head-eb20-j0_1-mc</elem>
+                <elem name="head-j2">head-eb21-j2_5-mc</elem>
+                <!-- ft -->
+            </paramlist>
+        </action>
+
+        <action phase="shutdown" level="2" type="detach" />
+
+    </device>


### PR DESCRIPTION

It fixes #85 

It has to be tested and it misses some API features of the library for work correctly
(see #86 and #88 )

It has to be merged after #84 

cc @AlexAntn @traversaro @S-Dafarra @drdanz 

