### PR TITLE
Add description list and path to the BufferManager configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ Here is the code snippet for dumping in a `.mat` file 3 samples of the 2x3 matri
     bm_m.resize(3);
     bm_m.setFileName("buffer_manager_test_matrix");
     bm_m.enablePeriodicSave(0.1); // This will try to save a file each 0.1 sec
+    bm_m.setDefaultPath("/my/preferred/path");
+    bm_m.setDescriptionList({"head", "left_arm"});
     std::vector<yarp::telemetry::ChannelInfo> vars{ { "one",{2,3} },
                                                     { "two",{3,2} } };
 
@@ -208,6 +210,9 @@ It is possible to load the configuration of a BufferManager **from a json file**
 Where the file has to have this format:
 ```json
 {
+    "description_list": ["This is a test",
+                         "Or it isn't?"],
+    "path":"/my/preferred/path",
     "filename": "buffer_manager_test_conf_file",
     "n_samples": 20,
     "save_period": 1.0,
@@ -218,7 +223,7 @@ Where the file has to have this format:
         ["one",[1,1]],
         ["two",[1,1]]
     ]
-  }
+}
 ```
 The configuration can be saved **to a json file**
 ```c++

--- a/src/examples/conf/test_json.json
+++ b/src/examples/conf/test_json.json
@@ -1,4 +1,6 @@
 {
+    "description_list": ["This is a test",
+                         "Or it isn't?"],
     "path":"",
     "filename": "buffer_manager_test_conf_file",
     "n_samples": 20,

--- a/src/examples/conf/test_json.json
+++ b/src/examples/conf/test_json.json
@@ -1,4 +1,5 @@
 {
+    "path":"",
     "filename": "buffer_manager_test_conf_file",
     "n_samples": 20,
     "save_period": 1.0,
@@ -9,4 +10,4 @@
         ["one",[1,1]],
         ["two",[1,1]]
     ]
-  }
+}

--- a/src/libYARP_telemetry/src/yarp/telemetry/BufferConfig.cpp
+++ b/src/libYARP_telemetry/src/yarp/telemetry/BufferConfig.cpp
@@ -13,7 +13,7 @@
 
 namespace yarp::telemetry {
     // This expects that the name of the json keyword is the same of the relative variable
-    NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(BufferConfig, path, filename, n_samples, save_period, data_threshold, auto_save, save_periodically, channels)
+    NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(BufferConfig, description_list, path, filename, n_samples, save_period, data_threshold, auto_save, save_periodically, channels)
 }
 bool bufferConfigFromJson(yarp::telemetry::BufferConfig& bufferConfig, const std::string& config_filename) {
     // read a JSON file

--- a/src/libYARP_telemetry/src/yarp/telemetry/BufferConfig.cpp
+++ b/src/libYARP_telemetry/src/yarp/telemetry/BufferConfig.cpp
@@ -13,7 +13,7 @@
 
 namespace yarp::telemetry {
     // This expects that the name of the json keyword is the same of the relative variable
-    NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(BufferConfig, filename, n_samples, save_period, data_threshold, auto_save, save_periodically, channels)
+    NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(BufferConfig, path, filename, n_samples, save_period, data_threshold, auto_save, save_periodically, channels)
 }
 bool bufferConfigFromJson(yarp::telemetry::BufferConfig& bufferConfig, const std::string& config_filename) {
     // read a JSON file

--- a/src/libYARP_telemetry/src/yarp/telemetry/BufferConfig.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/BufferConfig.h
@@ -25,6 +25,7 @@ using ChannelInfo = std::pair< std::string, dimensions_t >;
  *
  */
 struct YARP_telemetry_API BufferConfig {
+    std::vector<std::string> description_list; /** < the description list, e.g. it can contain the axes names that are logged*/
     std::string path{ "" }; /**< the path in which the files will be saved. */
     std::string filename{ "" };/**< the file name, to it will be appended the suffix "_<timestamp>.mat". */
     size_t n_samples{ 0 };/**< the max number of samples contained in the buffer/s */

--- a/src/libYARP_telemetry/src/yarp/telemetry/BufferConfig.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/BufferConfig.h
@@ -25,7 +25,7 @@ using ChannelInfo = std::pair< std::string, dimensions_t >;
  *
  */
 struct YARP_telemetry_API BufferConfig {
-    std::vector<std::string> description_list; /** < the description list, e.g. it can contain the axes names that are logged*/
+    std::vector<std::string> description_list{""}; /** < the description list, e.g. it can contain the axes names that are logged*/
     std::string path{ "" }; /**< the path in which the files will be saved. */
     std::string filename{ "" };/**< the file name, to it will be appended the suffix "_<timestamp>.mat". */
     size_t n_samples{ 0 };/**< the max number of samples contained in the buffer/s */

--- a/src/libYARP_telemetry/src/yarp/telemetry/BufferConfig.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/BufferConfig.h
@@ -25,6 +25,7 @@ using ChannelInfo = std::pair< std::string, dimensions_t >;
  *
  */
 struct YARP_telemetry_API BufferConfig {
+    std::string path{ "" }; /**< the path in which the files will be saved. */
     std::string filename{ "" };/**< the file name, to it will be appended the suffix "_<timestamp>.mat". */
     size_t n_samples{ 0 };/**< the max number of samples contained in the buffer/s */
     double save_period{ 0.010 };/**< the period in sec of the save thread */

--- a/src/libYARP_telemetry/src/yarp/telemetry/BufferManager.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/BufferManager.h
@@ -133,6 +133,16 @@ public:
     }
 
     /**
+     * @brief Set the path where the files will be saved.
+     *
+     * @param[in] path The path to be set.
+     */
+    void setDefaultPath(const std::string& path) {
+        m_bufferConfig.path = path;
+        return;
+    }
+
+    /**
      * @brief Resize the Buffer/s.
      *
      * @param[in] new_size The new size to be resized to.
@@ -295,6 +305,9 @@ public:
         // and finally we write the file
         // since we might save several files, we need to index them
         std::string new_file = m_bufferConfig.filename + "_" + std::to_string(m_nowFunction()) + ".mat";
+        if (!m_bufferConfig.path.empty()) {
+            new_file = m_bufferConfig.path + new_file;
+        }
         matioCpp::File file = matioCpp::File::Create(new_file);
         return file.write(timeSeries);
     }

--- a/src/libYARP_telemetry/src/yarp/telemetry/BufferManager.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/BufferManager.h
@@ -312,7 +312,11 @@ public:
 
 
         }
-        if (signalsVect.size() == 1) {
+        if (signalsVect.empty()) {
+            return false;
+        }
+        // This means that no variables are logged, we have only the description_list
+        else if (signalsVect.size() == 1 && m_description_cell_array.isValid()) {
             return false;
         }
         matioCpp::Struct timeSeries(m_bufferConfig.filename, signalsVect);
@@ -372,7 +376,7 @@ private:
             return;
         std::vector<matioCpp::Variable> descrListVect;
         for (const auto& str : m_bufferConfig.description_list) {
-            descrListVect.emplace_back(matioCpp::String(str));
+            descrListVect.emplace_back(matioCpp::String("useless_name",str));
         }
         matioCpp::CellArray description_list("description_list", { m_bufferConfig.description_list.size(), 1 }, descrListVect);
         m_description_cell_array = description_list;

--- a/test/BufferManagerTest.cpp
+++ b/test/BufferManagerTest.cpp
@@ -126,6 +126,7 @@ TEST_CASE("Buffer Manager Test")
     SECTION("Test configuration from/to file") {
         yarp::telemetry::BufferManager<int32_t> bm;
         yarp::telemetry::BufferConfig bufferConfig;
+        bufferConfig.description_list = { "Be", "Or not to be" };
         bufferConfig.channels = { {"one",{1,1}}, {"two",{1,1}} };
         bufferConfig.filename = "buffer_manager_test_conf_file";
         bufferConfig.n_samples = 20;
@@ -138,11 +139,15 @@ TEST_CASE("Buffer Manager Test")
         bool ok = bufferConfigFromJson(bufferConfig, "test_json_write.json");
         REQUIRE(ok);
 
+        REQUIRE(bufferConfig.description_list.size() == 2);
+        REQUIRE(bufferConfig.description_list[0] == "Be");
+        REQUIRE(bufferConfig.description_list[1] == "Or not to be");
         REQUIRE(bufferConfig.filename == "buffer_manager_test_conf_file");
         REQUIRE(bufferConfig.n_samples == 20);
         REQUIRE(bufferConfig.save_period == 1.0);
         REQUIRE(bufferConfig.data_threshold == 10);
         REQUIRE(bufferConfig.save_periodically == true);
+        REQUIRE(bufferConfig.channels.size() == 2);
         REQUIRE(bufferConfig.channels[0].first == "one");
         REQUIRE(bufferConfig.channels[0].second == std::vector<size_t>{1, 1});
         REQUIRE(bufferConfig.channels[1].first == "two");


### PR DESCRIPTION
It is now possible to specify a custom path(`path`) and a list of string(`description_list`) for describing the data logged.

```
>> buffer_manager_test_conf_file = 

  struct with fields:

    description_list: {2×1 cell}
                 one: [1×1 struct]
                 two: [1×1 struct]

>> buffer_manager_test_conf_file.description_list

ans =

  2×1 cell array

    {'This is a test'}
    {'Or it isn't?'  }
```



It fixes #86 
It fixes #88

 