### PR TITLE
Fix BufferManager configuration

### DIFF
--- a/src/libYARP_telemetry/src/yarp/telemetry/BufferManager.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/BufferManager.h
@@ -102,9 +102,13 @@ public:
      */
     bool configure(const BufferConfig& _bufferConfig) {
         bool ok{ true };
+        bool shouldResize = _bufferConfig.n_samples != m_bufferConfig.n_samples;
         m_bufferConfig = _bufferConfig;
         if (!_bufferConfig.channels.empty()) {
             ok = ok && addChannels(_bufferConfig.channels);
+        }
+        if (shouldResize) {
+            resize(_bufferConfig.n_samples);
         }
         if (ok && _bufferConfig.save_periodically) {
             ok = ok && enablePeriodicSave(_bufferConfig.save_period);

--- a/src/libYARP_telemetry/src/yarp/telemetry/BufferManager.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/BufferManager.h
@@ -102,13 +102,10 @@ public:
      */
     bool configure(const BufferConfig& _bufferConfig) {
         bool ok{ true };
-        bool shouldResize = _bufferConfig.n_samples != m_bufferConfig.n_samples;
+        resize(_bufferConfig.n_samples);
         m_bufferConfig = _bufferConfig;
         if (!_bufferConfig.channels.empty()) {
             ok = ok && addChannels(_bufferConfig.channels);
-        }
-        if (shouldResize) {
-            resize(_bufferConfig.n_samples);
         }
         if (ok && _bufferConfig.save_periodically) {
             ok = ok && enablePeriodicSave(_bufferConfig.save_period);
@@ -164,6 +161,9 @@ public:
      * @param[in] new_size The new size to be resized to.
      */
     void resize(size_t new_size) {
+        if (new_size == m_bufferConfig.n_samples) {
+            return;
+        }
         for (auto& [var_name, buff] : m_buffer_map) {
             buff.resize(new_size);
         }

--- a/src/libYARP_telemetry/src/yarp/telemetry/Record.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/Record.h
@@ -23,6 +23,10 @@ struct Record
     double m_ts;/**< timestamp */
     std::vector<T> m_datum;/**< the actual data of the record */
 
+    /**
+     * @brief Construct an empty Record object
+     *
+     */
     Record() = default;
 
     /**

--- a/src/libYARP_telemetry/src/yarp/telemetry/Record.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/Record.h
@@ -23,6 +23,8 @@ struct Record
     double m_ts;/**< timestamp */
     std::vector<T> m_datum;/**< the actual data of the record */
 
+    Record() = default;
+
     /**
      * @brief Construct a new Record object copying the _datum
      *

--- a/test/BufferManagerTest.cpp
+++ b/test/BufferManagerTest.cpp
@@ -101,7 +101,7 @@ TEST_CASE("Buffer Manager Test")
 
         yarp::telemetry::BufferConfig bufferConfig;
 
-        // we configure our API to use our periodic saving option 
+        // we configure our API to use our periodic saving option
         bufferConfig.n_samples = 20;
         bufferConfig.data_threshold = 10;
         bufferConfig.auto_save = true;
@@ -133,7 +133,7 @@ TEST_CASE("Buffer Manager Test")
         bufferConfig.save_period = 1.0;
         bufferConfig.data_threshold = 10;
         bufferConfig.save_periodically = true;
-        
+
         REQUIRE(bufferConfigToJson(bufferConfig, "test_json_write.json"));
 
         bool ok = bufferConfigFromJson(bufferConfig, "test_json_write.json");
@@ -161,6 +161,35 @@ TEST_CASE("Buffer Manager Test")
             yarp::os::Time::delay(0.01);
             bm.push_back({ i + 1 }, "two");
         }
+
+    }
+
+    SECTION("Test resize") {
+        yarp::telemetry::BufferManager<int32_t> bm;
+        yarp::telemetry::BufferConfig bufferConfig;
+
+        yarp::telemetry::ChannelInfo var_one{ "one", {1,1} };
+        yarp::telemetry::ChannelInfo var_two{ "two", {1,1} };
+        // First add channels that will be handling empty buffers
+        REQUIRE(bm.addChannel(var_one));
+        REQUIRE(bm.addChannel(var_two));
+
+        bufferConfig.description_list = { "Be", "Or not to be" };
+        bufferConfig.filename = "buffer_manager_test_resize";
+        bufferConfig.n_samples = 20;
+        bufferConfig.data_threshold = 10;
+        bufferConfig.save_periodically = false;
+
+        // This will resize the buffers
+        REQUIRE(bm.configure(bufferConfig));
+
+        for (int i = 0; i < 40; i++) {
+            bm.push_back({ i }, "one");
+            yarp::os::Time::delay(0.01);
+            bm.push_back({ i + 1 }, "two");
+        }
+
+        REQUIRE(bm.saveToFile());
 
     }
 


### PR DESCRIPTION
If you first add the channels and then configure the BM (with or without file) the size of the buffers was not updated.

Moreover, I had to add the default constructor of `Record` for resizing, I don't know why the "rule of zero" is violated.