### PR TITLE
Use push_back instead of emplace_back for the description cell

### DIFF
--- a/src/libYARP_telemetry/src/yarp/telemetry/BufferManager.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/BufferManager.h
@@ -250,7 +250,7 @@ public:
         std::scoped_lock<std::mutex> lock{ m_mutex };
         // Add the description
         if (m_description_cell_array.isValid()) {
-            signalsVect.emplace_back(m_description_cell_array);
+            signalsVect.push_back(m_description_cell_array);
         }
         // we have to force the flush.
         flush_all = flush_all || (m_bufferConfig.data_threshold > m_bufferConfig.n_samples);


### PR DESCRIPTION
For some reason, once it crashed here while running a test. In any case, since we want to copy, it does not make any sense to use emplace_back as that will call the copy constructor.