### PR TITLE
telemetryDeviceDumper: fix acceleration log

### DIFF
--- a/src/telemetryDeviceDumper/TelemetryDeviceDumper.cpp
+++ b/src/telemetryDeviceDumper/TelemetryDeviceDumper.cpp
@@ -312,7 +312,7 @@ void TelemetryDeviceDumper::readSensors()
         }
         else
         {
-            bufferManager.push_back(jointPos, "acceleration");
+            bufferManager.push_back(jointAcc, "acceleration");
         }
 
 


### PR DESCRIPTION
Fix the log of acceleration, it was a copy-past error.

See https://github.com/robotology-playground/yarp-telemetry/issues/87#issuecomment-800941099