### PR TITLE
BufferManager: introduce the usage of the condition variable

### DIFF
--- a/test/BufferManagerTest.cpp
+++ b/test/BufferManagerTest.cpp
@@ -193,4 +193,33 @@ TEST_CASE("Buffer Manager Test")
 
     }
 
+    SECTION("Test very long period") {
+        yarp::telemetry::BufferManager<int32_t> bm;
+        yarp::telemetry::BufferConfig bufferConfig;
+
+        yarp::telemetry::ChannelInfo var_one{ "one", {1,1} };
+        yarp::telemetry::ChannelInfo var_two{ "two", {1,1} };
+        // First add channels that will be handling empty buffers
+        REQUIRE(bm.addChannel(var_one));
+        REQUIRE(bm.addChannel(var_two));
+
+        bufferConfig.description_list = { "Be", "Or not to be" };
+        bufferConfig.filename = "buffer_manager_test_long_period";
+        bufferConfig.n_samples = 20;
+        bufferConfig.data_threshold = 10;
+        bufferConfig.save_periodically = true;
+        bufferConfig.auto_save = true;
+        bufferConfig.save_period = 3600; // Save every hour.
+
+        // This will resize the buffers
+        REQUIRE(bm.configure(bufferConfig));
+
+        for (int i = 0; i < 40; i++) {
+            bm.push_back({ i }, "one");
+            yarp::os::Time::delay(0.01);
+            bm.push_back({ i + 1 }, "two");
+        }
+
+    }
+
 }


### PR DESCRIPTION
This is used for handling the save thread and this should avoid awaiting
the thread save_period seconds to wake up in the closure phase.

It fixes #94

cc @S-Dafarra @lornat75 