### PR TITLE
BufferManager: fix multithreading push_back

### DIFF
--- a/src/libYARP_telemetry/src/yarp/telemetry/Buffer.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/Buffer.h
@@ -28,7 +28,7 @@ public:
     using iterator       =  typename boost::circular_buffer<Record<T>>::iterator;
     using const_iterator =  typename boost::circular_buffer<Record<T>>::const_iterator;
 
-    Buffer() = delete;
+    Buffer() = default;
 
     /**
      * @brief Construct a new Buffer object copying from another Buffer


### PR DESCRIPTION
It introduces the `BufferInfo` struct that holds the Buffer, the dimensions, and the mutex of the respective buffer. The push_back now lock the mutex of the buffer we are writing to it, keeping the others free.

It fixes #9 

cc @S-Dafarra 