### PR TITLE
Fix BufferManager buffer allocation in the configuration phase

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,7 +138,7 @@ if(BUILD_TESTING)
     find_package(Catch2 REQUIRED)
   else()
     include(FetchContent)
-    
+
     message(STATUS "Fetching Catch2...")
 
     FetchContent_Declare(Catch2
@@ -152,3 +152,5 @@ if(BUILD_TESTING)
 endif()
 
 set_property(GLOBAL PROPERTY USE_FOLDERS 1)
+
+include(AddUninstallTarget)

--- a/src/libYARP_telemetry/src/yarp/telemetry/Buffer.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/Buffer.h
@@ -115,6 +115,16 @@ public:
     }
 
     /**
+     * @brief Get the capacity of Buffer
+     *
+     * @return size_t The capacity of the buffer.
+     */
+    size_t capacity() const {
+        return m_buffer_ptr->capacity();
+
+    }
+
+    /**
      * @brief Return true if the Buffer is empty, false otherwise.
 
      *
@@ -130,6 +140,15 @@ public:
      */
     void resize(size_t new_size) {
         return m_buffer_ptr->resize(new_size);
+    }
+
+    /**
+     * @brief Change the capacity of the Buffer.
+     *
+     * @param[in] new_size The new size.
+     */
+    void set_capacity(size_t new_size) {
+        return m_buffer_ptr->set_capacity(new_size);
     }
 
     /**

--- a/src/libYARP_telemetry/src/yarp/telemetry/BufferManager.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/BufferManager.h
@@ -126,7 +126,7 @@ public:
      */
     bool configure(const BufferConfig& _bufferConfig) {
         bool ok{ true };
-        resize(_bufferConfig.n_samples);
+        set_capacity(_bufferConfig.n_samples);
         m_bufferConfig = _bufferConfig;
         if (!_bufferConfig.channels.empty()) {
             ok = ok && addChannels(_bufferConfig.channels);
@@ -185,11 +185,21 @@ public:
      * @param[in] new_size The new size to be resized to.
      */
     void resize(size_t new_size) {
-        if (new_size == m_bufferConfig.n_samples) {
-            return;
-        }
         for (auto& [var_name, buffInfo] : m_buffer_map) {
             buffInfo.m_buffer.resize(new_size);
+        }
+        m_bufferConfig.n_samples = new_size;
+        return;
+    }
+
+    /**
+     * @brief Set the capacity of Buffer/s.
+     *
+     * @param[in] new_size The new size.
+     */
+    void set_capacity(size_t new_size) {
+        for (auto& [var_name, buffInfo] : m_buffer_map) {
+            buffInfo.m_buffer.set_capacity(new_size);
         }
         m_bufferConfig.n_samples = new_size;
         return;
@@ -385,7 +395,7 @@ private:
     void periodicSave()
     {
         std::unique_lock<std::mutex> lk_cv(m_mutex_cv);
-        
+
         auto timeout =  std::chrono::duration<double>(m_bufferConfig.save_period);
         // For avoiding spurious wake up, the lambda check that the threads wake up only if we are trying to close
         // (additionally to the timeout expiration)

--- a/test/BufferManagerTest.cpp
+++ b/test/BufferManagerTest.cpp
@@ -234,7 +234,7 @@ TEST_CASE("Buffer Manager Test")
         REQUIRE(bm.addChannel(var_two));
 
         bufferConfig.description_list = { "Be", "Or not to be" };
-        bufferConfig.filename = "buffer_manager_test_resize";
+        bufferConfig.filename = "buffer_manager_test_set_capacity";
         bufferConfig.n_samples = 20;
         bufferConfig.data_threshold = 10;
         bufferConfig.save_periodically = false;

--- a/test/BufferManagerTest.cpp
+++ b/test/BufferManagerTest.cpp
@@ -176,12 +176,13 @@ TEST_CASE("Buffer Manager Test")
 
         bufferConfig.description_list = { "Be", "Or not to be" };
         bufferConfig.filename = "buffer_manager_test_resize";
-        bufferConfig.n_samples = 20;
         bufferConfig.data_threshold = 10;
         bufferConfig.save_periodically = false;
 
-        // This will resize the buffers
         REQUIRE(bm.configure(bufferConfig));
+
+        // Test resize
+        bm.resize(20);
 
         for (int i = 0; i < 40; i++) {
             bm.push_back({ i }, "one");
@@ -211,7 +212,7 @@ TEST_CASE("Buffer Manager Test")
         bufferConfig.auto_save = true;
         bufferConfig.save_period = 3600; // Save every hour.
 
-        // This will resize the buffers
+        // This will set_capacity the buffers
         REQUIRE(bm.configure(bufferConfig));
 
         for (int i = 0; i < 40; i++) {
@@ -219,6 +220,38 @@ TEST_CASE("Buffer Manager Test")
             yarp::os::Time::delay(0.01);
             bm.push_back({ i + 1 }, "two");
         }
+
+    }
+
+    SECTION("Test set_capacity") {
+        yarp::telemetry::BufferManager<int32_t> bm;
+        yarp::telemetry::BufferConfig bufferConfig;
+
+        yarp::telemetry::ChannelInfo var_one{ "one", {1,1} };
+        yarp::telemetry::ChannelInfo var_two{ "two", {1,1} };
+        // First add channels that will be handling empty buffers
+        REQUIRE(bm.addChannel(var_one));
+        REQUIRE(bm.addChannel(var_two));
+
+        bufferConfig.description_list = { "Be", "Or not to be" };
+        bufferConfig.filename = "buffer_manager_test_resize";
+        bufferConfig.n_samples = 20;
+        bufferConfig.data_threshold = 10;
+        bufferConfig.save_periodically = false;
+
+        // This will resize the buffers
+        REQUIRE(bm.configure(bufferConfig));
+
+        // Try to allocate a bigger buffer than what we need
+        bm.set_capacity(2000);
+
+        for (int i = 0; i < 40; i++) {
+            bm.push_back({ i }, "one");
+            yarp::os::Time::delay(0.01);
+            bm.push_back({ i + 1 }, "two");
+        }
+
+        REQUIRE(bm.saveToFile());
 
     }
 


### PR DESCRIPTION
BufferManager used to call `resize()` on the Buffers, I thought that it changed only `capacity()` and size() was changed only when `push_back` was invoked.

I changed the `resize()` call in `configure` to `set_capacity`

I tested this patch running `telemetryDeviceDumper` with the gazebo simulator.

It fixes #110 

cc @S-Dafarra 